### PR TITLE
Fix npm install error issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "webpack-cli": ">=2.0.13"
   },
   "subPackages": [
+    "contents",
     "closet-component-packages",
     "closet-default-component-packages",
     "content-manager",
     "tau-component-packages",
-    "contents",
     "design-editor"
   ],
   "repository": {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/20
[Problem] When doing npm install in DE error occurs
 Error: Cannot find module 'requirejs'
[Reason] Subpackage closet-default-component-packages has following
dependency defined:
"dress": "file:../contents"
when doing npm install for locally defined dependency npm is not
installing dependencies for contents form
../contents/package.json
Similar problem was reported in [1] and fixed in [2]
[Solution] Change order of packages installation so contents package is installed first

[1] https://npm.community/t/npm-install-for-package-with-local-dependency-fails/754/27
[2] https://github.com/npm/cli/pull/86/

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>