### PR TITLE
Remove the SmartThings menu in the Attribute

### DIFF
--- a/design-editor/src/panel/property/attribute/templates/attribute-element.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-element.html
@@ -24,15 +24,15 @@
     <ul class="closet-attribute-element-list closet-property-list closet-property-list-close"></ul>
         
     <!-- smart things -->
-    <div class="panel-heading closet-property-list-title">
+    <!-- <div class="panel-heading closet-property-list-title">
             <div class="closet-property-header">
                 <div class="closet-property-anchor">
                     <span class="fa fa-caret-right closet-property-list-title-icon"></span>
-                    <span class="title">Smart Things</span>
+                    <span class="title">Smart Things  - coming soon</span>
                 </div>
             </div>
         </div>
-        <ul class="closet-attribute-element-smartthings closet-property-list closet-property-list-close"></ul>
+        <ul class="closet-attribute-element-smartthings closet-property-list closet-property-list-close"></ul> -->
     
     <!-- box model -->
     <div class="panel-heading closet-property-list-title">


### PR DESCRIPTION
[Problme]There is not support the SmartThings.
[Solution]Temporary remove it.
         When activating SmartThings, the menu will also be enable.

Signed-off-by: cookie <cookie@samsung.com>