### PR TITLE
Fix HTML Assistant issues

### DIFF
--- a/brackets-extension/design-editor/libs/html-assistant-editor.js
+++ b/brackets-extension/design-editor/libs/html-assistant-editor.js
@@ -101,7 +101,7 @@ class HTMLAssistantEditor extends DressElement {
 
     layout(x, y) {
         var width = this.$el.innerWidth(),
-            max = editor.isAtom() ? 300 : 15;
+            max = 55;
 
         this.$el.css({
             left: Math.max(x - width, max),

--- a/design-editor/src/pane/select-layer/html-assistant.js
+++ b/design-editor/src/pane/select-layer/html-assistant.js
@@ -51,7 +51,8 @@ class HTMLAssistant {
 	 * @param {function} callback
 	 */
 	toggle(callback) {
-		if (this._htmlAssistantEditor.isOpened()) {
+		const opened = this._htmlAssistantEditor.isOpened();
+		if (opened) {
 			Promise.resolve(this._htmlAssistantEditor.getEditorContent())
 				.then((content) => {
 					this.setSelectedContent(content);
@@ -62,7 +63,7 @@ class HTMLAssistant {
 		} else {
 			this._htmlAssistantEditor.open(this.getSelectedContent(this.element));
 		}
-		callback(this._htmlAssistantEditor.isOpened())
+		callback(opened);
 	}
 
 	_bindEvents () {

--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -148,7 +148,7 @@ class StageManager {
     _toggleHTMLAssistant() {
         this._htmlAssistant.toggle((opened) => {
             console.log('HTML Assistant toggle', opened);
-            if (opened) {
+            if (!opened) {
                 this._toolbarContainerElement.turnOnControl(this._toolbarControls.INSTANT_EDIT);
             } else {
                 this._toolbarContainerElement.turnOffControl(this._toolbarControls.INSTANT_EDIT);


### PR DESCRIPTION
[Issue]: https://github.com/Samsung/TAU-Design-Editor/issues/33
[Problem]:
1. On WATT HTML-Assistant was too big and it was impossible to
close it.
2. HTML-Assistant icon wasn't toggled properly.
[Solution]: Change the width of HTML-Assistant and its position

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>