### PR TITLE
Repair .eslintrc for working with modules and CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "commonjs": true,
@@ -29,10 +30,13 @@
         "prefer-arrow-callback": "error",
         "prefer-template": "error",
         "no-unused-expressions": "error",
-        "max-len": ["error", {"code": 80}],
+        "max-len": ["error", {"code": 120}],
         "no-multiple-empty-lines": "error",
         "no-trailing-spaces": "error",
         "eol-last":"error",
         "lines-between-class-members":"error"
-        }
+        },
+        "parserOptions": {
+            "sourceType": "module"
+        }   
 }


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/58
Problem:
- We have one eslint config, but much more sub packages
(directories with its own package.json file) and files into them weren't
linted by this software.
- Bug on CI which tell that sourceType: module is needed

Solution: Add mandatory eslint rules to file

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>