### PR TITLE
Project launched in demo mode shows preview mode.

### DIFF
--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -9,6 +9,7 @@
 import $ from 'jquery';
 import {packageManager, Package} from 'content-manager';
 import {StateManager} from '../system/state-manager';
+import {stageManager} from '../system/stage-manager';
 import {SnapGuideManager} from './snap-guide-manager';
 import {Guide} from './guide';
 import {DressElement} from '../utils/dress-element';
@@ -31,10 +32,11 @@ import path, {relative} from 'path';
 
 const KEY_CODE = {
 	DELETE: 46
-};
-const INTERNAL_ID_ATTRIBUTE = 'data-id';
-const LOCK_CLASS = 'lock';
-const RE_COPY_ATTRIBUTE_TO_CONTAINER = new RegExp('^(data-(?!tau)|st-).*');
+	},
+	INTERNAL_ID_ATTRIBUTE = 'data-id',
+	LOCK_CLASS = 'lock',
+	RE_COPY_ATTRIBUTE_TO_CONTAINER = new RegExp('^(data-(?!tau)|st-).*'),
+	brackets = utils.checkGlobalContext('brackets');
 
 let _instance = null;
 
@@ -276,6 +278,7 @@ class DesignEditor extends DressElement {
 			}
 
 			this._$iframe.one('load', () => {
+				const isDemoVersion = utils.isDemoVersion(brackets);
 				removeMediaQueryConstraints(
 					this._$iframe[0].contentDocument,
 					pathUtils.createProjectPath(serverPath, true)
@@ -284,6 +287,9 @@ class DesignEditor extends DressElement {
 				this._selectLayer.refreshAltSelectors();
 				this._attachAlternativeSelectors(this._$iframe.contents()[0]);
 				this._updateIFrameHeight();
+				if (isDemoVersion) {
+					stageManager._onTogglePreview();
+				}
 				this._$iframe.css('visibility', 'visible');
 				eventEmitter.emit(EVENTS.ActiveEditorUpdated, 1, this);
 			});

--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -16,10 +16,11 @@ import {PreviewToolbarElement} from '../panel/preview/preview-toolbar-element';
 // import {InteractionViewElement} from '../panel/preview/interaction-view-element';
 // import {InteractionViewToolbarElement} from '../panel/preview/interaction-view-toolbar-element';
 import {InfoElement} from '../pane/select-layer/info-element';
+import utils from '../utils/utils';
 
-const CompositeDisposable = editor.CompositeDisposable;
-const DESIGN = ViewType.Design;
-const vscode = window.vscode;
+const CompositeDisposable = editor.CompositeDisposable,
+	DESIGN = ViewType.Design,
+	brackets = utils.checkGlobalContext('brackets');
 
 class StageManager {
     /**
@@ -237,7 +238,8 @@ class StageManager {
      */
     _togglePreview(toggleEditor) {
         var $workSpace = $(editor.selectors.workspace),
-            preview = null;
+			preview = null,
+			isDemoVersion = utils.isDemoVersion(brackets);
 
         if (!$workSpace.length) {
             $workSpace = $(document.body);
@@ -258,13 +260,14 @@ class StageManager {
 				}
 			);
 
-            if (window.atom !== undefined) {
-                this._toolbarContainerElementPanel.hide();
-                this._previewElementToolbarPanel.show();
-            } else {
-                $workSpace.children().first().before(this._previewElementToolbar);
-            }
+			if (!isDemoVersion) {
+				$workSpace.children().first().before(this._previewElementToolbar);
+			}
+
         } else {
+			if (isDemoVersion) {
+				return;
+			}
             $workSpace.removeClass('closet-preview-mode-active');
             window.setTimeout(() => {
                 $workSpace.find('closet-preview-element').remove();

--- a/design-editor/src/utils/utils.js
+++ b/design-editor/src/utils/utils.js
@@ -61,5 +61,18 @@ module.exports = {
 		});
 
 		return Promise.race([timeoutTriggerPromise, promise]);
+	},
+
+	/**
+	 * Checks if opened project is in demo mode
+	 *
+	 * @param {object} bracketsEditor
+	 * @returns {string} boolean
+	 */
+	isDemoVersion(bracketsEditor) {
+		if (bracketsEditor) {
+			const PreferencesManager = bracketsEditor.getModule('preferences/PreferencesManager');
+			return PreferencesManager.getViewState('projectType') === 'demo';
+		}
 	}
 };


### PR DESCRIPTION
[Problem] When project is in demo mode it should display only preview mode and HTML document. Editor mode is not available.
[Solution] When model of the project is loaded, launch preview mode. Add isDemoVersion variable which is a handler of project type.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>