### PR TITLE
Make preview toolbar available when demo mode is launched.

### DIFF
--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -260,8 +260,13 @@ class StageManager {
 				}
 			);
 
-			if (!isDemoVersion) {
-				$workSpace.children().first().before(this._previewElementToolbar);
+			$workSpace.children().first().before(this._previewElementToolbar);
+
+			if (isDemoVersion) {
+				const activatePreviewModeButton = document.getElementsByClassName('preview-toggle');
+				if (activatePreviewModeButton !== undefined) {
+					activatePreviewModeButton[0].style.display = 'none';
+				}
 			}
 
         } else {


### PR DESCRIPTION
[Problem] In demo mode only iframe with project waas displayed, without toolbar with back button.
Need to add toolbar to preview mode.
[Solution] Add preview toolbar, set display none to play button to not back to the editor mode.