### PR TITLE
Remove src attribute from edit area iframe

### DIFF
--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -152,8 +152,6 @@ class DesignEditor extends DressElement {
 
 		const appURI = uri.replace(/\/[^/]+$/gi, '');
 
-		this._$iframe.attr('src', uri);
-
 		// fill model document by HTML
 		documentForModel.documentElement.innerHTML = stringHTML;
 
@@ -438,7 +436,6 @@ class DesignEditor extends DressElement {
 	 * On ready callback
 	 */
 	onReady() {
-		this._$iframe.attr('src', this.options.uri);
 		this._$iframe.css('visibility', 'hidden');
 	}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/91
[Problem] Elements could not be added or selected due to missing
          data-id attibute, the problem caused incorrect html version
          to be loaded.
[Solution] Remove src attribute from iframe
           (html content is inserted using write() method).

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>