### PR TITLE
Made launching preview in demo mode with no-blink.

### DIFF
--- a/design-editor/src/brackets/brackets-editor.js
+++ b/design-editor/src/brackets/brackets-editor.js
@@ -13,7 +13,7 @@ import {BracketsStatusBarElement} from './brackets-status-bar';
 import {ConfigurationDesignAreaElement} from '../panel/configuration-design-area-element';
 import {stageManager} from '../system/stage-manager';
 import {appManager} from '../app-manager';
-
+import utils from '../utils/utils';
 import {DesignEditorElement} from '../pane/design-editor-element';
 import {panelManager} from '../system/panel-manager';
 import {EVENTS, eventEmitter} from '../events-emitter';
@@ -28,7 +28,8 @@ const beautyOptions = {
 	indent_char: ' ',
 	preserve_newlines: false,
 	unformatted: ['a', 'br', 'noscript', 'textarea', 'pre', 'code']
-};
+	},
+	isDemoVersion = utils.isDemoVersion();
 
 let _instance = null;
 let modelManager = null;
@@ -112,6 +113,10 @@ class BracketsEditor {
 
 					fs.readFile(window.top.globalData.fileUrl, 'utf8', (err, data) => {
 						if (err) throw err;
+						if (isDemoVersion) {
+							document.body.classList.add('closet-preview-mode');
+							document.body.classList.add('closet-preview-mode-active');
+						}
 						$('.closet-container').addClass('full design-view-active');
 						self.update(data, window.top.globalData);
 						element.show();

--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -20,7 +20,7 @@ import utils from '../utils/utils';
 
 const CompositeDisposable = editor.CompositeDisposable,
 	DESIGN = ViewType.Design,
-	brackets = utils.checkGlobalContext('brackets');
+	isDemoVersion = utils.isDemoVersion();
 
 class StageManager {
     /**
@@ -239,13 +239,12 @@ class StageManager {
 	_togglePreview(toggleEditor) {
 		let $workSpace = $(editor.selectors.workspace),
 			preview = null;
-		const isDemoVersion = utils.isDemoVersion();
 
         if (!$workSpace.length) {
             $workSpace = $(document.body);
         }
 
-        if (!$workSpace.hasClass('closet-preview-mode')) {
+		if (!$workSpace.hasClass('closet-preview-mode') || isDemoVersion) {
 			preview = new PreviewElement();
 			$workSpace.children().first().before(preview);
 			preview.show(
@@ -379,7 +378,9 @@ class StageManager {
             // init animation container
             // this._animationContainerElement.initialize(editor);
 
-            panelManager.openPanel({type: 'right', item: this._propertyContainerElement});
+			if (!isDemoVersion) {
+				panelManager.openPanel({type: 'right', item: this._propertyContainerElement});
+			}
             panelManager.openPanel({type: 'bottom', item: this._animationContainerElement});
 
             panelManager.openPanel({type: 'top', item: this._infoElement});


### PR DESCRIPTION
[Problem] In demo mode preview was loaded with blink of editor mode which change a view in a few seconds.
[Solution] Add class closet-preview mode to body to cover editor-mode.