### PR TITLE
HTML-Assistant: Handle Editor Close event

### DIFF
--- a/design-editor/src/pane/select-layer/html-assistant.js
+++ b/design-editor/src/pane/select-layer/html-assistant.js
@@ -48,13 +48,22 @@ class HTMLAssistant {
 	toggle(callback) {
 		const opened = this._htmlAssistantEditor.isOpened();
 		if (opened) {
-			Promise.resolve(this._htmlAssistantEditor.getEditorContent())
+			new Promise((resolve) => {
+				this._htmlAssistantEditor.close();
+				window.addEventListener('message', ({ data }) => {
+					if (data.type === 'VSCODE_MESSAGE' && data.info === 'EDITOR_CLOSED') {
+						resolve();
+					}
+				});
+			})
+				.then(() => this._htmlAssistantEditor.getEditorContent())
 				.then(content => this.setSelectedContent(content))
 				.then(() => {
 					this.element = this._model.getElementWithoutId(this.selectedElementId);
-					this._htmlAssistantEditor.close();
+					this._htmlAssistantEditor.clean();
 				})
 				.catch(error => console.error(error));
+
 		} else {
 			this._htmlAssistantEditor.open(this.getSelectedContent(this.element));
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "design-editor",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vsc-extension/design-editor/libs/html-assistant-editor.js
+++ b/vsc-extension/design-editor/libs/html-assistant-editor.js
@@ -4,52 +4,56 @@ const path = require('path');
 
 
 class HTMLAssistantEditorElement {
-    constructor() {
-        this._isOpened = false;
-        this._tempFileName = 'html-assistant-tmp.txt';
-    }
+	constructor() {
+		this._isOpened = false;
+		this._tempFileName = 'html-assistant-tmp.txt';
+	}
 
-    open(htmlText) {
-        fsExtra.writeFile(this._tempFileName, htmlText, (error) => {
-            if (error) {
-                console.error(error);
-            } else {
-                window.parent.postMessage({
-                    type: 'OPEN_EDITOR',
-                    file: this._tempFileName
-                }, '*');
-                this._isOpened = true;
-            }
-        });
-    }
+	open(htmlText) {
+		fsExtra.writeFile(this._tempFileName, htmlText, (error) => {
+			if (error) {
+				// eslint-disable-next-line no-console
+				console.error(error);
+			} else {
+				window.parent.postMessage({
+					type: 'OPEN_EDITOR',
+					file: this._tempFileName
+				}, '*');
+				this._isOpened = true;
+			}
+		});
+	}
 
-    close() {
-        window.parent.postMessage({
-            type: 'CLOSE_EDITOR'
-        }, '*');
-        this._isOpened = false;
-        fsExtra.deleteFile(this._tempFileName);
-    }
+	close() {
+		window.parent.postMessage({
+			type: 'CLOSE_EDITOR'
+		}, '*');
+		this._isOpened = false;
+	}
 
-    isOpened() {
-        return this._isOpened;
-    }
+	clean() {
+		fsExtra.deleteFile(this._tempFileName);
+	}
 
-    getEditorContent() {
-        const fullPath = path.resolve(
-            utils.checkGlobalContext('globalData').projectId,
-            this._tempFileName
-        );
+	isOpened() {
+		return this._isOpened;
+	}
 
-        return new Promise((resolve, reject) => {
-            fsExtra.readFile(fullPath, null, (error, result) => {
-                if (error) {
-                    reject(error);
-                }
-                resolve(result);
-            });
-        });
-    }
+	getEditorContent() {
+		const fullPath = path.resolve(
+			utils.checkGlobalContext('globalData').projectId,
+			this._tempFileName
+		);
+
+		return new Promise((resolve, reject) => {
+			fsExtra.readFile(fullPath, null, (error, result) => {
+				if (error) {
+					reject(error);
+				}
+				resolve(result);
+			});
+		});
+	}
 }
 
 export {HTMLAssistantEditorElement};

--- a/vsc-extension/design-editor/preview.html
+++ b/vsc-extension/design-editor/preview.html
@@ -21,8 +21,10 @@
     <script src="./less.js"></script>
     <script>
         window.vscode = true;
-        window.addEventListener('message', (event) => {
-            window.globalData = event.data;
+        window.addEventListener('message', (message) => {
+            if (message.data.type === 'CONFIG') {
+                window.globalData = message.data.payload;
+            }
         });
     </script>
 </head>


### PR DESCRIPTION
[Problem] There was a race in html-assistant between cleaning and saving
functions while closing editor window
[Solution] Create async chain of functions handling all needed actions
while clising editor window

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>