### PR TITLE
Enable preview refreshing in demo mode

### DIFF
--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -147,8 +147,6 @@ class DesignEditor extends DressElement {
 		let profile = this.screenConfig.profile;
 		console.log(`profile in screen configuration: ${  profile}`);
 
-		const appURI = uri.replace(/\/[^/]+$/gi, '');
-
 		// fill model document by HTML
 		documentForModel.documentElement.innerHTML = stringHTML;
 
@@ -190,7 +188,7 @@ class DesignEditor extends DressElement {
 				console.log(`updating model, new profile: ${  profile}`);
 				this._model.update(documentForModel);
 
-				changeAppProfile(appURI, profile)
+				changeAppProfile(pathUtils.createProjectPath(''), profile)
 					.then(() => {
 						console.log('config.xml successfuly changed');
 					})

--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -240,13 +240,13 @@ class StageManager {
 		let $workSpace = $(editor.selectors.workspace),
 			preview = null;
 
-        if (!$workSpace.length) {
-            $workSpace = $(document.body);
-        }
+		if (!$workSpace.length) {
+			$workSpace = $(document.body);
+		}
 
 		if (!$workSpace.hasClass('closet-preview-mode') || isDemoVersion) {
 			preview = new PreviewElement();
-			$workSpace.children().first().before(preview);
+			$workSpace.children().last().before(preview);
 			preview.show(
 				{
 					editor: toggleEditor || null,
@@ -259,33 +259,27 @@ class StageManager {
 				}
 			);
 
-			$workSpace.children().first().before(this._previewElementToolbar);
+			$workSpace.children().last().before(this._previewElementToolbar);
 
 			if (isDemoVersion) {
-				const activatePreviewModeButton = document.getElementsByClassName('preview-toggle');
-				if (activatePreviewModeButton !== undefined) {
-					activatePreviewModeButton[0].style.display = 'none';
+				const activatePreviewModeButton = document
+					.querySelector('closet-preview-element-toolbar .preview-toggle');
+				if (activatePreviewModeButton) {
+					activatePreviewModeButton.style.display = 'none';
 				}
 			}
 
-        } else {
-			if (isDemoVersion) {
-				return;
-			}
-            $workSpace.removeClass('closet-preview-mode-active');
-            window.setTimeout(() => {
-                $workSpace.find('closet-preview-element').remove();
-                $workSpace.removeClass('closet-preview-mode');
-            }, 500);
+		} else {
+			$workSpace.removeClass('closet-preview-mode-active');
+			window.setTimeout(() => {
+				$workSpace.find('closet-preview-element').remove();
+				$workSpace.removeClass('closet-preview-mode');
+			}, 500);
 
-            if (window.atom !== undefined) {
-                this._toolbarContainerElementPanel.show();
-                this._previewElementToolbarPanel.hide();
-            } else {
-                $workSpace.find('closet-preview-element-toolbar').remove();
-            }
-        }
-    }
+			$workSpace.find('closet-preview-element-toolbar').remove();
+		}
+	}
+
 
 	/**
 	 * Toggle preview


### PR DESCRIPTION
[Issue] #115
[Problem] After editing document preview wasn't refreshed:
	- Temporary file for preview wasn't deleted in DEMO mode
	- Preview panel wasn't destroyed when closed and new panels were
stacked upon it
[Solution] Adding to command-tau-preview the same functionality which
had preview element during detached.

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>