### PR TITLE
Fix for back button in design editor preview

### DIFF
--- a/design-editor/src/panel/preview/preview-element.js
+++ b/design-editor/src/panel/preview/preview-element.js
@@ -13,6 +13,7 @@ import {pipe} from '../../utils/utils';
 import { promisify } from 'util';
 
 const TEMPLATE_PATH = '/panel/preview/preview-element.html';
+let initalUrl = '';
 
 /**
  * Responsible for live-preview feature
@@ -69,6 +70,9 @@ class Preview extends DressElement {
 				this.setProfileStyle(position, $frame);
 
 				$frame.one('load', () => {
+					// Store first document URL for support for back button;
+					initalUrl = $frame[0].contentDocument.location.href;
+					// restore scroll position in iframe
 					this.scrollIframe.call(this, position, callback, $frame);
 				});
 
@@ -149,7 +153,7 @@ class Preview extends DressElement {
 		const contentDoc = this.$el.find('.closet-preview-frame')[0].contentDocument;
 		let event;
 
-		if (contentDoc) {
+		if (contentDoc && contentDoc.location.href !== initalUrl) {
 			event = new CustomEvent('tizenhwkey', {
 				'bubbles': true,
 				'cancelable': true
@@ -206,19 +210,9 @@ class Preview extends DressElement {
 		return xmlSerializer.serializeToString(doc);
 	}
 
-	addMainID(contents) {
-		const domParser = new DOMParser(),
-			xmlSerializer = new XMLSerializer(),
-			doc = domParser.parseFromString(contents, 'text/html');
-
-		doc.querySelector('.ui-page').setAttribute('id', 'main');
-		return xmlSerializer.serializeToString(doc);
-	}
-
 	signMainPage(contents) {
 		if (!checkGlobalContext('globalData').mainFile) {
 			checkGlobalContext('globalData').mainFile = checkGlobalContext('globalData').fileUrl;
-			return this.addMainID(contents);
 		}
 		return contents;
 	}


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/139
Problem: Selector widget doesn't show in example on code.tizen.org
Solution: The app UIComponents starts from inidex.html page with ID = "main",
 rest of pages in app have different page ID's and those ID cannot be changed
 bacause js code is dedicated to each page.
 After this patch the Design Editor will not trigger "tizenhwkey" for initial
 page.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>