### PR TITLE
Hide scrollbar for mobile in preview

### DIFF
--- a/design-editor/src/templates/preview-helper.css
+++ b/design-editor/src/templates/preview-helper.css
@@ -1,8 +1,8 @@
-.ui-scroller::-webkit-scrollbar {
+.ui-scroller::-webkit-scrollbar, .ui-scrollview-clip::-webkit-scrollbar {
 	display: none;
 }
 
-.ui-scroller {
+.ui-scroller, .ui-scrollview-clip {
 	-ms-overflow-style: none;
 	scrollbar-width: none;
 }


### PR DESCRIPTION
[Issue] N/A
[Problem] TAU uses different classnames for mobile
          profile than in wearable for scrollable area.
[Solution] Extend selector for styles that hide scrollbar
           to work with mobile profile too.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>