### PR TITLE
Parsing HTML references in temporary file

### DIFF
--- a/design-editor/src/utils/utils.js
+++ b/design-editor/src/utils/utils.js
@@ -79,7 +79,7 @@ export function isDemoVersion() {
  * @param {function} functions Array of functions to call
  */
 export function pipe (functions) {
-	return functions.reduce((f1, f2) => (a) => f2(f1(a)));
+	return functions.reduce((f1, f2) => (a, b) => f2(f1(a), b));
 }
 
 export default {


### PR DESCRIPTION
Issue: #137
Problem: POP-Up example didn't work properly
	- All references to HTML file were to original file hardcoded
Solution: Writing code that will remove references to file itself for
preview.
Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>