### PR TITLE
Enable dropdown menu visibility in DE

### DIFF
--- a/tau-component-packages/components/dropdownmenu/package.json
+++ b/tau-component-packages/components/dropdownmenu/package.json
@@ -16,7 +16,7 @@
       "tv": "./iot-dropdown.png"
     }
   },
-  "template": "<select data-native-menu=\"false\" data-inline=\"true\"></select>",
+  "template": "<select data-native-menu=\"false\" data-inline=\"true\" data-items=\"Add values\"></select>",
   "generator": {
     "constructor": "tau.widget.DropdownMenu",
     "parameter": {


### PR DESCRIPTION
Issue: #169
Problem: Dropdown menu wasn't visible in the design area right after D&D
this one.
Solution: Add default value to it so it is visible after dropping

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>