### PR TITLE
Enable ToggleSlider drag&drop funcionality

### DIFF
--- a/tau-component-packages/components/content/package.json
+++ b/tau-component-packages/components/content/package.json
@@ -59,7 +59,8 @@
     "tabs",
     "video",
     "anchor",
-    "tabs"
+    "tabs",
+    "toggleslider"
   ],
   "childrenLocation": {
     "mobile": ".ui-scrollview-view"

--- a/tau-component-packages/components/header/package.json
+++ b/tau-component-packages/components/header/package.json
@@ -20,7 +20,8 @@
       "toggleswitch",
       "iot-contextmenu",
       "box",
-      "button"
+      "button",
+      "toggleslider"
   ],
   "section": "header",
   "class": [

--- a/tau-component-packages/components/listitem/package.json
+++ b/tau-component-packages/components/listitem/package.json
@@ -52,7 +52,8 @@
     "box",
     "video",
     "anchor",
-    "box"
+    "box",
+    "toggleslider"
   ],
   "styles": [
     {

--- a/tau-component-packages/components/popup-content/package.json
+++ b/tau-component-packages/components/popup-content/package.json
@@ -23,6 +23,7 @@
     "input-text",
     "input-password",
     "input-date",
-    "input-number"
+    "input-number",
+    "toggleslider"
   ]
 }

--- a/tau-component-packages/components/section/package.json
+++ b/tau-component-packages/components/section/package.json
@@ -18,7 +18,8 @@
     "closet-image",
     "closet-tau-circle-progress",
     "box",
-    "button"
+    "button",
+    "toggleslider"
   ],
   "selector": ".ui-section-changer section",
   "template": "<section><span>Section</span></section>"


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/172
[Problem] It was impossible to drag and drop ToggleSlider onto user's
project
[Solution] Specify "content" and other containers as ones on which
ToggleSlider can be droppped

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>