### PR TITLE
Set placeholder to give image height and width

### DIFF
--- a/closet-component-packages/components/image/package.json
+++ b/closet-component-packages/components/image/package.json
@@ -4,7 +4,7 @@
   "attachable": true,
   "type": "standalone-component",
   "displayOrderWeight": 200,
-  "template": "<img class=\"ui-picture\" src=\"\" alt=\"\"  style=\"height: 100px;\">",
+  "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,
   "draggable": true,
   "resources": {


### PR DESCRIPTION
[Issue] #161
[Problem] Image dragged on template has height and width 0px
[Solution] Set placeholder to dragged image which initialized height and width to image widget.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>