### PR TITLE
Hide DE icon while going to Live Preview

### DIFF
--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -267,6 +267,9 @@ class StageManager {
 				if (activatePreviewModeButton) {
 					activatePreviewModeButton.style.display = 'none';
 				}
+			} else {
+				// Hide DE icon.
+				window.top.$('#tau-preview-icon').css('visibility', 'hidden');
 			}
 
 		} else {
@@ -277,6 +280,9 @@ class StageManager {
 			}, 500);
 
 			$workSpace.find('closet-preview-element-toolbar').remove();
+
+			// Restore DE icon since it may have been hidden while going to live preview.
+			window.top.$('#tau-preview-icon').css('visibility', 'visible');
 		}
 	}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/187

[Problem] Empty content after steeps:
    1. Go to DE mode (icon on right)
    2. Switch to Live Preview (icon on left)
    3. Go to Code Editing mode (icon on right)
    4. Go to DE mode (icon on right)

[Solution] Hide DE icon while going to Live Preview.

[TEST]
    0. Open any local sample.
    1. Go to DE mode (icon on right)
    2. Switch to Live Preview (icon on left)
    3. DE icon (on right) should not be visible.
    4. Switch to DE mode (icon on left).
    5. DE icon should be visible.

    1. Visit http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html
    2. DE icon (on right) should be visible.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>