### PR TITLE
Fixup! Set placeholder to give image height and width

### DIFF
--- a/contents/src/components/image/package.json
+++ b/contents/src/components/image/package.json
@@ -4,7 +4,7 @@
   "attachable": true,
   "type": "standalone-component",
   "displayOrderWeight": 200,
-  "template": "<img class=\"ui-picture\" src=\"\" alt=\"\"  style=\"height: 100px;\">",
+  "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,
   "draggable": true,
   "resources": {


### PR DESCRIPTION
[Issue] #161
[Problem] jsonf file for image is replaced during rebuild
[Solution] Modify source instead

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>