### PR TITLE
DropDownMenu: Enabling component visibility only for mobile profile

### DIFF
--- a/tau-component-packages/components/dropdownmenu/package.json
+++ b/tau-component-packages/components/dropdownmenu/package.json
@@ -17,6 +17,7 @@
     }
   },
   "template": "<select data-native-menu=\"false\" data-inline=\"true\" data-items=\"Add values\"></select>",
+  "version": "mobile",
   "generator": {
     "constructor": "tau.widget.DropdownMenu",
     "parameter": {


### PR DESCRIPTION
Issue: N/A
Problem: DropDownMenu for wearable profile is not implemented
Solution: Visibility of DropDownMenu component has allowed
 only for mobile profile.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>