### PR TITLE
Remove edit mode toggle

### DIFF
--- a/design-editor/src/panel/toolbar-element.html
+++ b/design-editor/src/panel/toolbar-element.html
@@ -26,10 +26,10 @@
         disabled="true" title="New Page">
     <i class="fa fa-magic fa-file"></i>
 </button>
-<button class="closet-toolbar-button closet-toolbar-toggle-button selected edit-mode-toggle"
+<!-- <button class="closet-toolbar-button closet-toolbar-toggle-button selected edit-mode-toggle"
         disabled="true" title="Edit Mode Toggle">
     <i class="fa fa-pencil-square-o fa-lg"></i>
-</button>
+</button> -->
 <button class="closet-toolbar-button closet-toolbar-toggle-button layout-detail-toggle"
         disabled="true" title="Detail layout">
     <i class="fa fa-crosshairs fa-lg"></i>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/209
[Problem] Edit mode toggle is currently not needed.
[Solution] Dissable edit mode button from toolbar

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>