### PR TITLE
Fix changing dimensions after dragging element

### DIFF
--- a/design-editor/src/pane/interaction.js
+++ b/design-editor/src/pane/interaction.js
@@ -286,6 +286,13 @@ class Interaction {
             height: $contentElement.outerHeight()
         };
 
+		// store element width and height, because of dragging changes
+		// positioning type and element may lost it's dimensions
+		$contentElement.css({
+			'width': $contentElement.css('width'),
+			'height': $contentElement.css('height')
+		});
+
         $selectLayerParent[0].showHighlighter($contentElement.parent()[0]);
 
         // Make parent offset root if it's not already


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/213
[Problem] Element after dragging has absolute position which
          may interfere it's dimensions.
[Solution] Store element width and height before starting
           dragging

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>