### PR TITLE
Disable DropDownMenu for wearable profile.

### DIFF
--- a/design-editor/src/panel/property/component/component-element.js
+++ b/design-editor/src/panel/property/component/component-element.js
@@ -268,17 +268,17 @@ class Component extends DressElement {
      * @private
      */
     _selectComponentsToDeviceProfile(componentInfo) {
-        var self = this,
-            components = {},
-            comp = null;
+		let components = {},
+			comp = null,
+			screen = StateManager.get('screen');
 
-        for (comp in componentInfo) {
-            let componentProfileList = componentInfo[comp].options[DEVICE_PROFILE_OPTION];
-            if (!componentProfileList || componentProfileList.indexOf(self._profile) !== -1) {
-                components[comp] = componentInfo[comp];
-            }
-        }
-        return components;
+		for (comp in componentInfo) {
+			let componentProfileList = componentInfo[comp].options[DEVICE_PROFILE_OPTION];
+			if (!componentProfileList || componentProfileList.indexOf(screen.profile) !== -1) {
+				components[comp] = componentInfo[comp];
+			}
+		}
+		return components;
     }
 
     /**

--- a/design-editor/src/panel/property/component/component-element.js
+++ b/design-editor/src/panel/property/component/component-element.js
@@ -262,24 +262,24 @@ class Component extends DressElement {
         self._render();
     }
 
-    /**
+	/**
      * Return list of components, which could be available in current design editor profile
      * @param {Object} componentInfo
      * @private
      */
-    _selectComponentsToDeviceProfile(componentInfo) {
-		let components = {},
-			comp = null,
+	_selectComponentsToDeviceProfile(componentInfo) {
+		let comp = null;
+		const components = {},
 			screen = StateManager.get('screen');
 
 		for (comp in componentInfo) {
-			let componentProfileList = componentInfo[comp].options[DEVICE_PROFILE_OPTION];
+			const componentProfileList = componentInfo[comp].options[DEVICE_PROFILE_OPTION];
 			if (!componentProfileList || componentProfileList.indexOf(screen.profile) !== -1) {
 				components[comp] = componentInfo[comp];
 			}
 		}
 		return components;
-    }
+	}
 
     /**
      * Fill component info at panel

--- a/tau-component-packages/components/dropdownmenu/package.json
+++ b/tau-component-packages/components/dropdownmenu/package.json
@@ -18,6 +18,7 @@
   },
   "template": "<select data-native-menu=\"false\" data-inline=\"true\" data-items=\"Add values\"></select>",
   "version": "mobile",
+  "device-profile": "mobile",
   "generator": {
     "constructor": "tau.widget.DropdownMenu",
     "parameter": {

--- a/tau-component-packages/components/selector/package.json
+++ b/tau-component-packages/components/selector/package.json
@@ -23,6 +23,7 @@
     "selectoritem"
   ],
   "version": "wearable-circle",
+  "device-profile": "wearable",
   "data": [
     {
       "option": "item-selector",


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/210
Problem: Drop Down Menu for wearable profile is not supported
Solution:
 - Configure DropDownMenu only for mobile profile
 - fix for Component selection for different profiles
 - added profie configuration for Selector refering to this patch

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>