### PR TITLE
Add circle-helper.js script to make Slider works correctly.

### DIFF
--- a/design-editor/src/pane/design-editor.js
+++ b/design-editor/src/pane/design-editor.js
@@ -991,7 +991,7 @@ class Model {
 
 	addLibrary(libraryName) {
 		const helper = this._libraryCreator.createLibrary(libraryName);
-		if (!this._DOM.querySelector(helper.getSelector())) {
+		if (!this._DOM.head.querySelector(helper.getSelector())) {
 			this._DOM.head.appendChild(
 				helper.createHTMLElement(
 					utils.checkGlobalContext('globalData').fileUrl


### PR DESCRIPTION
[Issue]: #215
[Problem]: Slider doesn't look correctly in preview mode and after save.
[Solution]: Look for circle-helper.js only in head, cause another circle-helper.js is added and appears in html of iframe.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>