### PR TITLE
ToggleSlider: changing visibility only for mobile profile.

### DIFF
--- a/tau-component-packages/components/toggleslider/package.json
+++ b/tau-component-packages/components/toggleslider/package.json
@@ -17,6 +17,7 @@
     }
   },
   "template": "<input type=\"checkbox\" class=\"ui-toggleswitch\" data-appearance=\"slider\">",
+  "version": "mobile",
   "generator": {
     "constructor": "tau.widget.ToggleSwitch",
     "parameter": {


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/192
Problem: ToggleSlider is not implemented in wearable profile.
Solution: In wearable from version 1.1, ToggleSwitch looks like ToggleSlider.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>