### PR TITLE
Make it possible to open JS Assistant Wizard

### DIFF
--- a/brackets-extension/design-editor/libs/assistant-view/assistant-view-element.js
+++ b/brackets-extension/design-editor/libs/assistant-view/assistant-view-element.js
@@ -132,47 +132,45 @@ class AssistantView extends DressElement {
 		return matched ? $element : null;
 	}
 
-    /**
-     * Element drag callback
-     * @param {Event} event
-     * @private
-     */
-    _onElementDrag(event) {
-        var pointedElement,
-            $lineElement,
-            lineNumber,
-            textEditorElement = this._$textEditorEl && this._$textEditorEl[0] || null;
+	/**
+	 * Element drag callback
+	 * @param {Event} event
+	 * @private
+	 */
+	_onElementDrag(event) {
+		const pointedElement = document.elementFromPoint(event.clientX, event.clientY),
+			$lineElement = AssistantView._getSelectableItem(pointedElement, ['.CodeMirror-code > div']);
+		let lineNumber;
 
-        // brackets version
-        pointedElement = document.elementFromPoint(event.clientX, event.clientY);
-        $lineElement = AssistantView._getSelectableItem(pointedElement, ['.CodeMirror-code > div']);
-        if ($lineElement) {
-            lineNumber = $lineElement.parent().children().index($lineElement[0]);
-        }
+		if ($lineElement) {
+			lineNumber = $lineElement.parent().children().index($lineElement[0]);
+		}
 
-        if ($lineElement) {
-            this.setCursorPosition([lineNumber, 0]);
-        }
-    }
+		if ($lineElement) {
+			this.setCursorPosition([lineNumber, 0]);
+		}
+	}
 
-    /**
-     * Element drag stop
-     * @private
-     */
-    _onElementDragStop() {
-        eventEmitter.emit(EVENTS.OpenAssistantWizard);
-    }
+	/**
+	 * Element drag stop
+	 * @private
+	 */
+	_onElementDragStop() {
+		if (this.isOpened()) {
+			eventEmitter.emit(EVENTS.OpenAssistantWizard);
+		}
+	}
 
-    /**
-     * Set grammar
-     * @param {Object} grammar
-     */
-    setGrammar(grammar) {
-        if (this._currentGrammar !== grammar) {
-            this._currentGrammar = grammar;
-            this._textEditor.setGrammar(grammar);
-        }
-    }
+	/**
+	 * Set grammar
+	 * @param {Object} grammar
+	 */
+	setGrammar(grammar) {
+		if (this._currentGrammar !== grammar) {
+			this._currentGrammar = grammar;
+			this._textEditor.setGrammar(grammar);
+		}
+	}
 
     /**
      * Set content

--- a/design-editor/src/panel/assistant/assistant-view-element.js
+++ b/design-editor/src/panel/assistant/assistant-view-element.js
@@ -168,13 +168,15 @@ class AssistantView extends DressElement {
         }
     }
 
-    /**
-     * Element drag stop
-     * @private
-     */
-    _onElementDragStop() {
-        eventEmitter.emit(EVENTS.OpenAssistantWizard);
-    }
+	/**
+	 * Element drag stop
+	 * @private
+	 */
+	_onElementDragStop() {
+		if (this.isOpened()) {
+			eventEmitter.emit(EVENTS.OpenAssistantWizard);
+		}
+	}
 
     /**
      * Set grammar

--- a/design-editor/src/system/assistant/assistant-manager.js
+++ b/design-editor/src/system/assistant/assistant-manager.js
@@ -96,7 +96,6 @@ class AssistantManager {
 		});
 	}
 
-
 	/**
 	 * Getting reference to ScriptElement from model or undefined if not exists
 	 * @param  {String} fileName name of JS file
@@ -119,11 +118,7 @@ class AssistantManager {
 	}
 
 	_bindEvents() {
-		eventEmitter.on(EVENTS.OpenAssistantWizard, () => {
-			// this._onOpenAssistantCodeWizard.bind(this);
-			// eslint-disable-next-line no-console
-			console.warn('feature of drag&drop elements to JS assistant isn\'t implemented yet');
-		});
+		eventEmitter.on(EVENTS.OpenAssistantWizard, this._onOpenAssistantCodeWizard.bind(this));
 		eventEmitter.on(EVENTS.AssistantWizardAccepted, this._onWizardAccepted.bind(this));
 	}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/223
[Problem] It was impossible to open JS Assistant Wizard
[Solution] Restore EventListener on OpenAssistantWizard, add check if JS
Assistant is open (wizard should only be triggered when JS Assistant is
opened)

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>