### PR TITLE
Unfocus back button in preview mode

### DIFF
--- a/design-editor/src/panel/preview/preview-element.js
+++ b/design-editor/src/panel/preview/preview-element.js
@@ -161,6 +161,11 @@ class Preview extends DressElement {
 			event.keyName = 'back';
 			contentDoc.body.dispatchEvent(event);
 		}
+		const backwardButton = document
+			.querySelector('closet-preview-element-toolbar .preview-backward');
+		if (backwardButton) {
+			backwardButton.blur();
+		}
 	}
 
 	/**


### PR DESCRIPTION
[Issue] #239
[Problem] Back button stays focused after clicking back
[Solution] Unfocus back button using blur()

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>