### PR TITLE
Remove XMLSerializer to parse preview document.

### DIFF
--- a/design-editor/src/panel/preview/preview-element.js
+++ b/design-editor/src/panel/preview/preview-element.js
@@ -211,7 +211,6 @@ class Preview extends DressElement {
 		const libraryName = 'preview-helper.css',
 			library = this.libraryCreator.createLibrary(libraryName),
 			domParser = new DOMParser(),
-			xmlSerializer = new XMLSerializer(),
 			doc = domParser.parseFromString(contents, 'text/html');
 
 		doc.head.appendChild(
@@ -225,7 +224,7 @@ class Preview extends DressElement {
 			console.log(`[OK] Library ${libraryName} copied`);
 		});
 
-		return xmlSerializer.serializeToString(doc);
+		return doc.documentElement.innerHTML;
 	}
 
 }


### PR DESCRIPTION
[Problem]: XMLSerializer causes changing <a> to HTML entities and don't read <a> as tag.
[Solution]: Change method of translation to string from XMLSerializer to innerHTML.
[Issue]: #164