### PR TITLE
Fix behaviour panel - data exposing problem

### DIFF
--- a/design-editor/src/panel/property/behavior/behavior-element.js
+++ b/design-editor/src/panel/property/behavior/behavior-element.js
@@ -203,15 +203,15 @@ class Behavior extends DressElement {
 							$content = $content.next();
 							$content.find('.behavior-type').val(behavior.type);
 							$content = $content.next();
+							if (behavior.type === 'page') {
+								$content.find('.behavior-page-name').css('display', 'inline-block');
+								$content.find('.behavior-animation-name').css('display', 'none');
+							} else {
+								$content.find('.behavior-animation-name').css('display', 'inline-block');
+								$content.find('.behavior-page-name').css('display', 'none');
+							}
 							Object.keys(behavior.options).forEach((key) => {
-								$content.find(`.behavior-${  key}`).val(behavior.options[key]);
-								if (behavior.type === 'page') {
-									$content.find('.behavior-page-name').css('display', 'inline-block');
-									$content.find('.behavior-animation-name').css('display', 'none');
-								} else {
-									$content.find('.behavior-animation-name').css('display', 'inline-block');
-									$content.find('.behavior-page-name').css('display', 'none');
-								}
+								$content.find(`.behavior-${key}`).val(behavior.options[key]);
 							});
 						});
 					});

--- a/design-editor/src/panel/property/behavior/behaviour-element.spec.js
+++ b/design-editor/src/panel/property/behavior/behaviour-element.spec.js
@@ -1,7 +1,0 @@
-import {BehaviorElement} from './behavior-element';
-
-describe('BehaviorElement', function () {
-    it('should be a HTML Element', function () {
-        expect(new BehaviorElement() instanceof HTMLElement).toBe(true);
-    });
-});


### PR DESCRIPTION
Issue: #118
Problem: After refresh behaviour option select doesn't show proper value
Solution: Fix bugs in behaviour panel code, prevent potential memory
leaks

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>