### PR TITLE
Make structure tree view scrollable

### DIFF
--- a/design-editor/styles/design-editor/structure-element.less
+++ b/design-editor/styles/design-editor/structure-element.less
@@ -6,6 +6,9 @@ closet-structure-element {
     background-color: @app-background-color;
     border-top: 1px solid #111;
     flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
     .closet-structure-element-title {
         display: block;
         flex: 1;


### PR DESCRIPTION
Issue: #177
Problem: Structure element wasn't scrollable even if there is too many
components to fit one screen view.
Solution: Add proper styling to file

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>