### PR TITLE
Fix for displaying preview

### DIFF
--- a/design-editor/src/panel/preview/preview-element.js
+++ b/design-editor/src/panel/preview/preview-element.js
@@ -178,8 +178,9 @@ class Preview extends DressElement {
 	createPreviewDocument(contents, location) {
 		const relativePathToFile = pathUtils.joinPaths(path.dirname(location), 'temporary-preview.html'),
 			writeFile = promisify(fs.writeFile),
-			processPipe = pipe([addDoctypeDeclaration, removeMediaQueryConstraints,
+			processPipe = pipe([removeMediaQueryConstraints,
 				this.addHelperCSSLibrary.bind(this),
+				addDoctypeDeclaration,
 				this.removeFileReferance.bind(this)]),
 			parsedContents = processPipe(contents, location);
 


### PR DESCRIPTION
[Issue]: N/A
[Problem]: Previous change causes not adding doctype to HTML which is displayed in preview.
[Solution]: Change order of executed functions in pipe.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>