### PR TITLE
Make input for box-shadow larger

### DIFF
--- a/design-editor/src/panel/property/attribute/templates/attribute-box-model.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-box-model.html
@@ -18,7 +18,7 @@
 </li>
 <li class="closet-attribute-common-border">
     <span class="closet-attribute-common-label-long">box shadow</span>
-    <input type="text" name="boxShadow" class="native-key-bindings closet-attribute-common-textbox">
+    <input type="text" name="boxShadow" class="native-key-bindings closet-attribute-common-textbox long-controls">
 </li>
 <li class="closet-attribute-common-border">
     <span class="closet-attribute-common-label">border</span>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/171
[Problem] The input for box-shadow was too small
[Solution] Set long-controls class to box-shadow input (which sets it's
width to 124px)

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>