### PR TITLE
Add input-border-warning less variable to VSC code

### DIFF
--- a/vsc-extension/design-editor/styles-brackets/ui-variables.less
+++ b/vsc-extension/design-editor/styles-brackets/ui-variables.less
@@ -87,6 +87,7 @@
 
 @input-background-color:           darken(@base-background-color, 6%);
 @input-border-color:               @base-border-color;
+@input-border-warning:             @background-color-warning;
 
 @tool-panel-background-color:      @level-3-color;
 @tool-panel-border-color:          @base-border-color;


### PR DESCRIPTION
[Problem] There was an issue with input-border-warning less  variable
that was used both by VSC and WATT but only avaliable for WATT
[Solution] Add input-border-warning less variable to VSC code

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>