### PR TITLE
Preview mode appears always in the center of the screen

### DIFF
--- a/design-editor/styles/design-editor/preview.less
+++ b/design-editor/styles/design-editor/preview.less
@@ -1,5 +1,8 @@
 closet-preview-element {
-    display:block;
+	display:flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items:center;
     width: 100%;
     height: 100%;
     position: absolute;
@@ -10,7 +13,6 @@ closet-preview-element {
 }
 
 .closet-preview-container {
-    position: absolute;
     width: 360px;
     height: 360px;
     top: 50%;


### PR DESCRIPTION
[Issue]: #189
[Problem]: When structure tree is opened in edit mode, preview move to the left.
[Solution] Change some styles for preview.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>