### PR TITLE
Enable to use useExistVar in JS assistant

### DIFF
--- a/design-editor/src/panel/assistant/assistant-wizard.js
+++ b/design-editor/src/panel/assistant/assistant-wizard.js
@@ -125,7 +125,8 @@ class AssistantWizard extends DressElement {
      */
     _bindEvent() {
         this._$useCustomEventCheckbox.on('click', this._onClickCustom.bind(this));
-        this._$actionPresetGroup.on('click', this._onClickPreset.bind(this));
+		this._$actionPresetGroup.on('click', this._onClickPreset.bind(this));
+		this._$usingExistInstanceCheckbox.on('click', this._onClickUseExistVar.bind(this));
     }
 
     /**
@@ -165,6 +166,20 @@ class AssistantWizard extends DressElement {
 
         this._showPresetOptions(presetName);
     }
+
+	/**
+     * On click useExistVar checkbox callback
+     * @param {Event} event
+     * @private
+     */
+	_onClickUseExistVar(event){
+		const isCheckboxChecked = event.target.checked;
+		if (!isCheckboxChecked) {
+			this._$instanceList[0].style = 'display:none;';
+		} else {
+			this._$instanceList[0].style = 'display:flex;';
+		}
+	}
 
     /**
      * Show preset

--- a/design-editor/src/system/assistant/assistant-code-generator.js
+++ b/design-editor/src/system/assistant/assistant-code-generator.js
@@ -252,11 +252,11 @@ class AssistantCodeGenerator {
      * @private
      */
     _setValueToMap(map, key, value) {
-        const stored = this._getValueFromMap(map, key);
+		const stored = this._getValueFromMap(map, key[0]);
 
-        stored.push(value);
-        map.set(key, stored);
-    }
+		stored.push(value);
+		map.set(key[0], stored);
+	}
 
     /**
      * Get value form map
@@ -265,8 +265,8 @@ class AssistantCodeGenerator {
      * @returns {*}
      * @private
      */
-    _getValueFromMap(map, key) {
-        return map.get(key) || [];
+	_getValueFromMap(map, key) {
+		return map.get(key[0]) || [];
     }
 }
 


### PR DESCRIPTION
[Problem] User can't select "use Exist Var" checkbox and use a variable to add events.
[Solution] Add function to display select list of variables and change key in weakmap from jquery object to DOM element.
[Issue]: #184

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>