### PR TITLE
Switch to tau.history.back in helper

### DIFF
--- a/design-editor/src/panel/preview/preview-element.js
+++ b/design-editor/src/panel/preview/preview-element.js
@@ -13,7 +13,6 @@ import {pipe} from '../../utils/utils';
 import { promisify } from 'util';
 
 const TEMPLATE_PATH = '/panel/preview/preview-element.html';
-let initalUrl = '';
 
 /**
  * Responsible for live-preview feature
@@ -70,8 +69,6 @@ class Preview extends DressElement {
 				this.setProfileStyle(position, $frame);
 
 				$frame.one('load', () => {
-					// Store first document URL for support for back button;
-					initalUrl = $frame[0].contentDocument.location.href;
 					// restore scroll position in iframe
 					this.scrollIframe.call(this, position, callback, $frame);
 				});
@@ -153,7 +150,7 @@ class Preview extends DressElement {
 		const contentDoc = this.$el.find('.closet-preview-frame')[0].contentDocument;
 		let event;
 
-		if (contentDoc && contentDoc.location.href !== initalUrl) {
+		if (contentDoc) {
 			event = new CustomEvent('tizenhwkey', {
 				'bubbles': true,
 				'cancelable': true

--- a/design-editor/src/templates/back-button-support.js
+++ b/design-editor/src/templates/back-button-support.js
@@ -14,7 +14,7 @@
 				} catch (ignore) {
 				}
 			} else {
-				history.back();
+				tau.history.back();
 			}
 		}
 	});


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/166
[Problem] Unable to go back in panel history
[Solution] Use tau.history.back() method in helper in order to change panel
Remove condition of checking first page - this is alread done in tau.history.back()

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>