### PR TITLE
Enlarge scrollable containers on focus

### DIFF
--- a/design-editor/src/panel/property/component/component-element.js
+++ b/design-editor/src/panel/property/component/component-element.js
@@ -3,7 +3,6 @@
 import path from 'path';
 import mustache from 'mustache';
 import $ from 'jquery';
-import jqueryUI from 'jquery-ui';
 import {packageManager, Package} from 'content-manager';
 import {appManager as AppManager} from '../../../app-manager';
 import {DressElement} from '../../../utils/dress-element';

--- a/design-editor/src/system/stage-manager.js
+++ b/design-editor/src/system/stage-manager.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import $ from 'jquery';
+
 import AssistantManager from './assistant/assistant-manager';
 import {EVENTS, eventEmitter} from '../events-emitter';
 import {panelManager} from './panel-manager';
@@ -13,8 +14,6 @@ import HTMLAssistant from '../pane/select-layer/html-assistant';
 import {ToolbarElement} from '../panel/toolbar-element';
 import {PreviewElement} from '../panel/preview/preview-element';
 import {PreviewToolbarElement} from '../panel/preview/preview-toolbar-element';
-// import {InteractionViewElement} from '../panel/preview/interaction-view-element';
-// import {InteractionViewToolbarElement} from '../panel/preview/interaction-view-toolbar-element';
 import {InfoElement} from '../pane/select-layer/info-element';
 import utils from '../utils/utils';
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/176
[Problem] It was impossible to view or edit containers which elements
have larger combined height that the containers themselves
[Solution] Enlarge container on focus to the height equal of combined
height of its descendants

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>