### PR TITLE
Prevent page wizard broken while DE scaling

### DIFF
--- a/design-editor/styles/design-editor/page-wizard.less
+++ b/design-editor/styles/design-editor/page-wizard.less
@@ -131,6 +131,8 @@ closet-page-wizard {
             -webkit-flex: 9;
             background-color: @background-color-highlight;
             padding: 10px;
+            height: 100%;
+            box-sizing: border-box;
             closet-pw-thumbnail {
                 display : -webkit-flex;
                 flex-direction: column;


### PR DESCRIPTION
Issue: #277
Problem: While user use page scaling more than 100% page wizard is too
big to close it
Solution: Define height of big container
Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>