### PR TITLE
Enable adding the text and image widgets to header

### DIFF
--- a/tau-component-packages/components/header/package.json
+++ b/tau-component-packages/components/header/package.json
@@ -21,7 +21,9 @@
       "iot-contextmenu",
       "box",
       "button",
-      "toggleslider"
+      "toggleslider",
+      "text",
+      "image"
   ],
   "section": "header",
   "class": [


### PR DESCRIPTION
Issue: #261
Problem: Cannot add Image and Text widget to header
Solution: Add it to constraint in header widget manifest

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>