### PR TITLE
Remove the Layout attribute

### DIFF
--- a/design-editor/src/panel/property/attribute/templates/attribute-element.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-element.html
@@ -128,7 +128,7 @@
     </div>
 
     <!-- layout -->
-    <div class="panel-draggable">
+    <!--<div class="panel-draggable">
         <div class='panel-heading closet-property-list-title'>
             <div class="closet-property-header">
                 <div class="closet-property-anchor">
@@ -138,7 +138,7 @@
             </div>
         </div>
         <ul class='closet-layout-element-list closet-property-list closet-property-list-close'></ul>
-    </div>
+    </div>-->
 
     <!-- interative 3D -->
     <div class="panel-draggable closet-interactive-element">


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/268
Problem : Layout attribute is not working
Solution : Remove the item

Signed-off-by: cookie <cookie@samsung.com>