### PR TITLE
TextInput: Fix for moving text input component

### DIFF
--- a/closet-default-component-packages/components/input-number/package.json
+++ b/closet-default-component-packages/components/input-number/package.json
@@ -1,6 +1,7 @@
 {
     "label": "Input Number",
-    "selector": "input[type=number]",
+    "selector": "input[type=number], .ui-text-input-container.ui-text-input-type-number",
+    "baseElementSelector": "input[type=number]",
     "attachable": true,
     "displayOrderWeight": 800,
     "type": "standalone-component",
@@ -20,10 +21,10 @@
         "options": {}
       }
     },
-    "template": "<input type=\"number\"/>",
+    "template": "<input type=\"number\" data-outside-div=\"true\"/>",
     "snippet": [
       {
-        "snippet": "<input type=\"number\" name=\"${5:mytext}\" id=\"${3:text-test}\"/>\n<label for=\"${4:text-test}\">${1:InputText}</label>",
+        "snippet": "<input type=\"number\" data-outside-div=\"true\" name=\"${5:mytext}\" id=\"${3:text-test}\"/>\n<label for=\"${4:text-test}\">${1:InputText}</label>",
         "displayText": "inputNumber",
         "description": "Enter your number."
       }

--- a/closet-default-component-packages/components/input-password/package.json
+++ b/closet-default-component-packages/components/input-password/package.json
@@ -1,6 +1,7 @@
 {
   "label": "Input Password",
-  "selector": "input[type=password]",
+  "selector": "input[type=password], .ui-text-input-container.ui-text-input-type-password",
+  "baseElementSelector": "input[type=password]",
   "attachable": true,
   "displayOrderWeight": 1000,
   "type": "standalone-component",
@@ -14,10 +15,10 @@
         "tv": "./input-password-mobile.png"
     }
   },
-  "template": "<input type=\"password\"/>",
+  "template": "<input type=\"password\"  data-outside-div=\"true\"/>",
   "snippet": [
     {
-      "snippet": "<input type=\"password\" name=\"${4:mypassword}\" id=\"${2:password-test}\"/>\n<label for=\"${3:password-test}\">${1:InputPassword}</label>",
+      "snippet": "<input type=\"password\" data-outside-div=\"true\" name=\"${4:mypassword}\" id=\"${2:password-test}\"/>\n<label for=\"${3:password-test}\">${1:InputPassword}</label>",
       "displayText": "inputPassword",
       "description": "Enter your text."
     }

--- a/closet-default-component-packages/components/input-text/package.json
+++ b/closet-default-component-packages/components/input-text/package.json
@@ -1,6 +1,8 @@
 {
+    "name": "input-text",
     "label": "Input Text",
-    "selector": "input[type=text]",
+    "selector": "input[type=text], .ui-text-input-container.ui-text-input-type-text",
+    "baseElementSelector": "input[type=text]",
     "attachable": true,
     "displayOrderWeight": 900,
     "type": "standalone-component",
@@ -20,10 +22,10 @@
         "options": {}
       }
     },
-    "template": "<input type=\"text\"/>",
+    "template": "<input type=\"text\" data-outside-div=\"true\"/>",
     "snippet": [
       {
-        "snippet": "<input type=\"text\" name=\"${5:mytext}\" id=\"${3:text-test}\"/>\n<label for=\"${4:text-test}\">${1:InputText}</label>",
+        "snippet": "<input type=\"text\" data-outside-div=\"true\" name=\"${5:mytext}\" id=\"${3:text-test}\"/>\n<label for=\"${4:text-test}\">${1:InputText}</label>",
         "displayText": "inputText",
         "description": "Enter your text."
       }

--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -102,6 +102,19 @@ function toggleParentModifications($element, componentPackage, forceState) {
 	});
 }
 
+/**
+ * Regular expression for find words in uppercase
+ */
+const bigRegexp = /[A-Z]/g;
+
+/**
+ * Method change camel case string to dashed string
+ * eg. simpleStyleProperty -> simple-style-property
+ */
+function camelCaseToDashes(name) {
+	return name.replace(bigRegexp, c => `-${  c.toLowerCase()}`);
+}
+
 class DesignEditor extends DressElement {
 	/**
 	 * Update data
@@ -677,8 +690,9 @@ class DesignEditor extends DressElement {
 	 * @param {string} value style new value
 	 */
 	_onStyleChanged(id, name, value) {
-		const bigRegexp = /[A-Z]/g;
-		this._getElementById(id).css(name.replace(bigRegexp, c => `-${  c.toLowerCase()}`), value);
+		const $element = this._getElementById(id).first();
+
+		$element.css(camelCaseToDashes(name), value);
 		this._requiredSyncSelector = true;
 		requestAnimationFrame(this._syncSelector.bind(this));
 	}


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/234
Problem: TextInput - Widget cannot be moved properly
Solution: Text input is wrapped in container because widget
 contains line below input.

This PR is depend to TAU patch https://github.com/Samsung/TAU/pull/343

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>