### PR TITLE
Enable adding the image and checkbox widgets to header

### DIFF
--- a/tau-component-packages/components/header/package.json
+++ b/tau-component-packages/components/header/package.json
@@ -23,7 +23,9 @@
       "button",
       "toggleslider",
       "text",
-      "image"
+      "closet-image",
+      "checkbox",
+      "radio"
   ],
   "section": "header",
   "class": [


### PR DESCRIPTION
Issue : https://github.com/Samsung/TAU-Design-Editor/issues/261
Problem : Can't add the image widget in header
Solution:Add it to constraint in header widget manifest

Signed-off-by: cookie <cookie@samsung.com>