### PR TITLE
Add configurable parent method call after deleting element

### DIFF
--- a/design-editor/src/pane/component-generator.js
+++ b/design-editor/src/pane/component-generator.js
@@ -107,7 +107,7 @@ class ComponentGenerator {
 			return {
 				constructor: info.options.generator.constructor,
 				parameter: info.options.generator.parameter,
-				dependencyComponent: info.options.generator['dependency-component'],
+				dependencyComponent: info.options['dependency-component'],
 				parentMethodToCall: info.options.generator['parent-call-method']
 			};
 		}

--- a/tau-component-packages/components/selectoritem/package.json
+++ b/tau-component-packages/components/selectoritem/package.json
@@ -18,13 +18,16 @@
     "text",
     "closet-image"
   ],
+  "dependency-component": "selector",
   "generator": {
-    "dependency-component": "selector",
     "constructor": "",
     "parameter": {
       "options": {}
     },
     "parent-call-method": "addItem"
+  },
+  "destroyer": {
+    "parent-call-method": "removeItemByElement"
   },
   "class": [],
   "attributes": {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/279
[Problem] Some complex widgets require removing elements
          through its API. Otherwise widget look is broken.
[Solution] Call given parent method on widget if required

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>