### PR TITLE
Remove the Attributes->Element->Widget options

### DIFF
--- a/content-manager/src/package-component.js
+++ b/content-manager/src/package-component.js
@@ -19,11 +19,6 @@ var COMMON_ATTRIBUTE = {
         'type': 'text',
         'value': ''
     },
-    'data-options': {
-        'label': 'Widget options',
-        'type': 'text',
-        'value': ''
-    },
     'model': {
         'label': 'Model',
         'widget-option': true,


### PR DESCRIPTION
Issue : https://github.com/Samsung/TAU-Design-Editor/issues/267
Problem: widget option is not working
Solution : The items is not needed. So remove it.

Signed-off-by: cookie <cookie@samsung.com>