### PR TITLE
Hide Text Attribute for components that doesn't contain text

### DIFF
--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -947,7 +947,6 @@ class DesignEditor extends DressElement {
 	 * @param {HTMLElement} element
 	 * @returns {HTMLElement|null}
 	 */
-
 	getContainerByElement(element) {
 		const iframeDocument = this._$iframe[0].contentDocument;
 		const tau = iframeDocument.defaultView.tau;
@@ -1144,8 +1143,8 @@ class DesignEditor extends DressElement {
 		this._selectLayer.screenShape = screenConfig.shape;
 
 		$(this._selectLayer).css({
-			width: `${adjustedWidth  }px`,
-			height: `${adjustedHeight  }px`,
+			width: `${adjustedWidth}px`,
+			height: `${adjustedHeight}px`,
 			top: `-webkit-calc((50% - ${  (screenConfig.height * screenConfig.ratio) / 2  }px))`
 		});
 		this._selectLayer.makeHoverScroller();

--- a/design-editor/src/pane/guide.js
+++ b/design-editor/src/pane/guide.js
@@ -132,6 +132,7 @@ class Guide {
 					this._$lastGuideElement.remove();
 				}
 			}
+
 			if (!isComponentAllowedInThisContainer) {
 				this._onDestroyGuide();
 				if (rule) {

--- a/design-editor/src/panel/property/attribute/attribute-element.js
+++ b/design-editor/src/panel/property/attribute/attribute-element.js
@@ -3,6 +3,7 @@
 import fs from 'fs';
 import $ from 'jquery';
 import {packageManager, Package} from 'content-manager';
+
 import {appManager as AppManager} from '../../../app-manager';
 import {DressElement} from '../../../utils/dress-element';
 import {EVENTS, eventEmitter} from '../../../events-emitter';
@@ -11,8 +12,7 @@ import {AttributeLayoutElement} from './attribute-element-layout';
 import {AttributeSmartThingsElement} from './attribute-element-sthings';
 import {AttributeInteractiveElement} from './attribute-element-interactive';
 import {AttributeImageElement} from './attribute-element-image';
-import {AttributeCheckboxElement} from './attribute-element-checkbox'
-import editor from '../../../editor';
+import {AttributeCheckboxElement} from './attribute-element-checkbox';
 import utils from '../../../utils/utils';
 import attributeUtils from '../../../utils/attribute-utils';
 
@@ -59,6 +59,7 @@ function rgba2hex(rgba) {
  *
  */
 class Attribute extends DressElement {
+
     /**
      * Create callback
      */
@@ -208,6 +209,12 @@ class Attribute extends DressElement {
             } else {
                 $el.find('.closet-coverflow-element').hide();
             }
+
+			if (modelElement.component && modelElement.component.options.textEditable) {
+				$el.find('.closet-text-element').show();
+			} else {
+				$el.find('.closet-text-element').hide();
+			}
 
             if (modelElement.component && modelElement.component.name === 'closet-image') {
                 $el.find('.closet-image-element').show();

--- a/design-editor/src/panel/property/attribute/templates/attribute-element.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-element.html
@@ -22,7 +22,7 @@
         </div>
     </div>
     <ul class="closet-attribute-element-list closet-property-list closet-property-list-close"></ul>
-        
+
     <!-- smart things -->
     <div class="panel-heading closet-property-list-title">
             <div class="closet-property-header">
@@ -33,7 +33,7 @@
             </div>
         </div>
         <ul class="closet-attribute-element-smartthings closet-property-list closet-property-list-close"></ul>
-    
+
     <!-- box model -->
     <div class="panel-heading closet-property-list-title">
         <div class="closet-property-header">
@@ -79,15 +79,17 @@
     <ul class="closet-attribute-flex-list closet-property-list closet-property-list-close"></ul>
 
     <!-- text -->
-    <div class="panel-heading closet-property-list-title">
-        <div class="closet-property-header">
-            <div class="closet-property-anchor">
-                <span class="fa fa-caret-right closet-property-list-title-icon"></span>
-                <span class="title">Text</span>
+    <div class="panel-draggable closet-text-element">
+        <div class="panel-heading closet-property-list-title">
+            <div class="closet-property-header">
+                <div class="closet-property-anchor">
+                    <span class="fa fa-caret-right closet-property-list-title-icon"></span>
+                    <span class="title">Text</span>
+                </div>
             </div>
         </div>
+        <ul class="closet-text-element-list closet-property-list closet-property-list-close"></ul>
     </div>
-    <ul class="closet-text-element-list closet-property-list closet-property-list-close"></ul>
 
     <!-- image -->
     <div class="panel-draggable closet-image-element">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/265
[Problem] All attributes have beem shown regardless of the selected
component
[Solution] Components that have textEditable property are granted access
to Text attribute

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>