### PR TITLE
Hide Text Attribute for components that doesn't contain text

### DIFF
--- a/closet-component-packages/components/image/package.json
+++ b/closet-component-packages/components/image/package.json
@@ -3,6 +3,7 @@
   "selector": "img.ui-picture",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 200,
   "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,

--- a/closet-component-packages/components/page/package.json
+++ b/closet-component-packages/components/page/package.json
@@ -8,6 +8,7 @@
     "js": "./page.js",
     "css": "./page.css"
   },
+  "textEditable": false,
   "attributes": {},
   "behaviors": {
     "events": {

--- a/closet-default-component-packages/components/input-number/package.json
+++ b/closet-default-component-packages/components/input-number/package.json
@@ -4,6 +4,7 @@
     "baseElementSelector": "input[type=number]",
     "attachable": true,
     "displayOrderWeight": 800,
+    "textEditable": false,
     "type": "standalone-component",
     "resources": {
       "css": [

--- a/closet-default-component-packages/components/input-password/package.json
+++ b/closet-default-component-packages/components/input-password/package.json
@@ -4,6 +4,7 @@
   "baseElementSelector": "input[type=password]",
   "attachable": true,
   "displayOrderWeight": 1000,
+  "textEditable": true,
   "type": "standalone-component",
   "resources": {
     "css": [

--- a/closet-default-component-packages/components/input-text/package.json
+++ b/closet-default-component-packages/components/input-text/package.json
@@ -6,6 +6,7 @@
     "attachable": true,
     "displayOrderWeight": 900,
     "type": "standalone-component",
+    "textEditable": true,
     "resources": {
       "css": [
         "./styles/input-text.css"

--- a/contents/src/components/button/package.json
+++ b/contents/src/components/button/package.json
@@ -7,6 +7,7 @@
     "js": "button.js",
     "css": "button.css"
   },
+  "textEditable": true,
   "attributes": {
     "button-text": {
       "label": "Text",

--- a/contents/src/components/image/package.json
+++ b/contents/src/components/image/package.json
@@ -3,6 +3,7 @@
   "selector": "img.ui-picture",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 200,
   "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,

--- a/contents/src/components/tau-circle-progress/package.json
+++ b/contents/src/components/tau-circle-progress/package.json
@@ -4,6 +4,7 @@
   "attachable": false,
   "type": "standalone-component",
   "altSelector": true,
+  "textEditable": false,
   "resources": {
     "js": "tau-circle-progress.js",
     "css": "./tau-circle-progress.css",

--- a/design-editor/src/panel/property/attribute/attribute-element.js
+++ b/design-editor/src/panel/property/attribute/attribute-element.js
@@ -196,43 +196,54 @@ class Attribute extends DressElement {
 				.getElement(_selectedElementId);
 			iframeElement = designEditor._getElementById(_selectedElementId);
 			this._computedStyle = window.getComputedStyle(iframeElement[0]);
-			if (modelElement.component && modelElement.component.name === 'i3d') {
+
+			const { component } = modelElement;
+			if (component && component.name === 'i3d') {
 				$el.find('.closet-interactive-element').show();
 				interactiveElement.setData(modelElement);
 			} else {
 				$el.find('.closet-interactive-element').hide();
 			}
 
-			if (modelElement.component && modelElement.component.name === 'coverflow') {
+			if (component && component.name === 'coverflow') {
 				$el.find('.closet-coverflow-element').show();
 			} else {
 				$el.find('.closet-coverflow-element').hide();
 			}
 
-			if (modelElement.component && modelElement.component.name === 'closet-image') {
+			if (component && component.name === 'closet-image') {
 				$el.find('.closet-image-element').show();
 				self._imageElement.setData(iframeElement);
 			} else {
 				$el.find('.closet-image-element').hide();
 			}
-			if (modelElement.component && modelElement.component.name === 'checkbox') {
+
+			if (component && component.options.textEditable) {
+				$el.find('.closet-text-element').show();
+			} else {
+				$el.find('.closet-text-element').hide();
+			}
+
+			if (component && component.name === 'checkbox') {
 				$el.find('.closet-checkbox-element').show();
 				self._checkboxElement.setData(iframeElement, modelElement);
 			} else {
 				$el.find('.closet-checkbox-element').hide();
 			}
-			if (modelElement.component && !(['text', 'title'].includes(modelElement.component.name))) {
+
+			if (component && !(['text', 'title'].includes(component.name))) {
 				self.expand('closet-additional-attribute', self._expandable);
 			} else {
 				self.unexpand('closet-additional-attribute', self._expandable);
 			}
-			if (modelElement.component && modelElement.component.options.options) {
+
+			if (component && component.options.options) {
 				$el.find('.closet-property-widget-option').show();
 			} else {
 				$el.find('.closet-property-widget-option').hide();
 			}
 
-			attributes = modelElement.component && modelElement.component.getAttributes();
+			attributes = component && component.getAttributes();
 
 			if (attributes) {
 				attributes.forEach((attributeObject) => {

--- a/design-editor/src/panel/property/attribute/templates/attribute-element.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-element.html
@@ -22,7 +22,7 @@
         </div>
     </div>
     <ul class="closet-attribute-element-list closet-property-list closet-property-list-close"></ul>
-        
+
     <!-- smart things -->
     <div class="panel-heading closet-property-list-title">
             <div class="closet-property-header">
@@ -33,7 +33,7 @@
             </div>
         </div>
         <ul class="closet-attribute-element-smartthings closet-property-list closet-property-list-close"></ul>
-    
+
     <!-- box model -->
     <div class="panel-heading closet-property-list-title">
         <div class="closet-property-header">
@@ -78,16 +78,18 @@
     </div>
     <ul class="closet-attribute-flex-list closet-property-list closet-property-list-close"></ul>
 
-    <!-- text -->
-    <div class="panel-heading closet-property-list-title">
-        <div class="closet-property-header">
-            <div class="closet-property-anchor">
-                <span class="fa fa-caret-right closet-property-list-title-icon"></span>
-                <span class="title">Text</span>
-            </div>
-        </div>
-    </div>
-    <ul class="closet-text-element-list closet-property-list closet-property-list-close"></ul>
+	<!-- text -->
+	<div class="panel-draggable closet-text-element">
+		<div class="panel-heading closet-property-list-title">
+			<div class="closet-property-header">
+				<div class="closet-property-anchor">
+					<span class="fa fa-caret-right closet-property-list-title-icon"></span>
+					<span class="title">Text</span>
+				</div>
+			</div>
+		</div>
+		<ul class="closet-text-element-list closet-property-list closet-property-list-close"></ul>
+	</div>
 
     <!-- image -->
     <div class="panel-draggable closet-image-element">

--- a/tau-component-packages/components/button/package.json
+++ b/tau-component-packages/components/button/package.json
@@ -7,6 +7,7 @@
       "options": {}
     }
   },
+  "textEditable": true,
   "resources": {
     "css": [
       "../../tau/theme/tau.min.css",

--- a/tau-component-packages/components/checkbox/package.json
+++ b/tau-component-packages/components/checkbox/package.json
@@ -3,6 +3,7 @@
   "selector": ":not(.ui-toggleswitch) > input[type=checkbox]:not(.ui-slider-switch-input):not([data-role=toggleswitch]):not(.ui-toggleswitch), input[type=checkbox]:not(.ui-toggleswitch)",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 400,
   "resources": {
     "css": [

--- a/tau-component-packages/components/progress/package.json
+++ b/tau-component-packages/components/progress/package.json
@@ -4,6 +4,7 @@
   "attachable": true,
   "type": "standalone-component",
   "displayOrderWeight": 1500,
+  "textEditable": false,
   "resources": {
     "css": [
       "../../tau/theme/tau.min.css",

--- a/tau-component-packages/components/radio/package.json
+++ b/tau-component-packages/components/radio/package.json
@@ -3,6 +3,7 @@
   "selector": "input[type=radio]",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 500,
   "resources": {
     "css": [

--- a/tau-component-packages/components/slider/package.json
+++ b/tau-component-packages/components/slider/package.json
@@ -5,6 +5,7 @@
   "attachable": true,
   "type": "standalone-component",
   "displayOrderWeight": 700,
+  "textEditable": false,
   "resources": {
     "css": [
       "../../tau/theme/tau.min.css",

--- a/tau-component-packages/components/toggleswitch/package.json
+++ b/tau-component-packages/components/toggleswitch/package.json
@@ -4,6 +4,7 @@
   "baseElementSelector": "input.ui-toggle-switch",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 600,
   "resources": {
     "css": [

--- a/tau-component-packages/libs/closet/1.0.0/components/button/package.json
+++ b/tau-component-packages/libs/closet/1.0.0/components/button/package.json
@@ -7,6 +7,7 @@
     "js": "button.js",
     "css": "button.css"
   },
+  "textEditable": true,
   "attributes": {
     "button-text": {
       "label": "Text",

--- a/tau-component-packages/libs/closet/1.0.0/components/image/package.json
+++ b/tau-component-packages/libs/closet/1.0.0/components/image/package.json
@@ -3,8 +3,9 @@
   "selector": "img.ui-picture",
   "attachable": true,
   "type": "standalone-component",
+  "textEditable": false,
   "displayOrderWeight": 200,
-  "template": "<img class=\"ui-picture\" src=\"\" alt=\"\"  style=\"height: 100px;\">",
+  "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,
   "draggable": true,
   "resources": {

--- a/tau-component-packages/libs/closet/1.0.0/components/tau-circle-progress/package.json
+++ b/tau-component-packages/libs/closet/1.0.0/components/tau-circle-progress/package.json
@@ -4,6 +4,7 @@
   "attachable": false,
   "type": "standalone-component",
   "altSelector": true,
+  "textEditable": false,
   "resources": {
     "js": "tau-circle-progress.js",
     "css": "./tau-circle-progress.css",


### PR DESCRIPTION
[Issue] #265
[Problem] All attributes have beem shown regardless of the selected
component
[Solution] Components that have textEditable property are granted access
to Text attribute

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>