### PR TITLE
Make button to return to Editor mode more intuitive.

### DIFF
--- a/design-editor/src/panel/preview/preview-toolbar-element.html
+++ b/design-editor/src/panel/preview/preview-toolbar-element.html
@@ -1,4 +1,4 @@
 <div class="closet-toolbar-container-element">
-    <button class="closet-toolbar-button closet-toolbar-toggle-button preview-toggle selected"><i class="fa fa-play fa-lg"></i></button>
-    <button class="closet-toolbar-button closet-toolbar-toggle-button preview-backward"><i class="fa fa-play fa-chevron-left fa-lg"></i></button>
+    <button class="closet-toolbar-button closet-toolbar-toggle-button preview-toggle exit" title="Back to the Editor mode"><i class="fa fa-times fa-lg"></i></button>
+    <button class="closet-toolbar-button closet-toolbar-toggle-button preview-backward" title="Back to previous opened page"><i class="fa fa-play fa-chevron-left fa-lg"></i></button>
 </div>

--- a/design-editor/styles/design-editor/toolbar-element.less
+++ b/design-editor/styles/design-editor/toolbar-element.less
@@ -22,6 +22,11 @@ closet-toolbar-container-element,
             color: @text-color-selected;
         }
 
+		&.exit {
+			background-color: @background-color-warning;
+			color: @text-color-selected;
+		}
+
         &.closet-toolbar-button-hidden {
             display: none;
         }


### PR DESCRIPTION
[Problem]: The button to go back to Editor mode is a play button which is not intuitive.
[Solution]: Change the icon and a color of button.
[Issue]: #270

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>