### PR TITLE
Enable adding header to the empty page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+**/**.min.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,8 @@
         "no-trailing-spaces": "error",
         "eol-last":"error",
         "lines-between-class-members":"error",
-        "keyword-spacing":"error"
+        "keyword-spacing":"error",
+        "complexity":"error"
         },
         "parserOptions": {
             "sourceType": "module"

--- a/design-editor/src/pane/guide.js
+++ b/design-editor/src/pane/guide.js
@@ -83,7 +83,9 @@ class Guide {
 
 		if (!$target.hasClass(CLASS_NAME.GUIDE_ELEMENT) && !$target.closest(`.${CLASS_NAME.GUIDE_ELEMENT}`).length) {
 			isComponentAllowedInThisContainer = $.inArray(packageInfo.name, allowedPackagenameListInContainer) !== -1;
-
+			/**
+			 * Check if proper container element exists
+			 */
 			if (packageInfo.options['parent-constraint']) {
 				if (!$target.closest(containerInfo.$element).length) {
 					return;
@@ -103,6 +105,18 @@ class Guide {
 			} else {
 				// element does not exists in container or element is outside container
 				rule = this._getInsertedRule(targetInfo, containerInfo.$element, isRestrict, containerInfo);
+			}
+
+			/**
+			 * @todo This should be fixed during refactor
+			 * Header as a element had parent-constraint but cannot be append to the end of siblings elements
+			 * like it is coded in 93. line
+			 */
+			if (packageInfo.name == 'header') {
+				rule = {
+					direction: 'before',
+					element: containerInfo.$element.children().first()
+				};
 			}
 
 			if (
@@ -264,14 +278,17 @@ class Guide {
         return $container.children('[' + INTERNAL_ID_ATTRIBUTE + ']' + selector);
     }
 
-    /**
-     * Insert Rule
-     * @param {Object} targetInfo
-     * @param {jQuery} $container
-     * @param {boolean} isRestrict
-     * @returns {*}
-     * @private
-     */
+	/**
+	 * Responsible for way in which element is inserted to document
+	 * before or after elements in the same scope
+	 * @param {Object} targetInfo - current target (first element under mouse pointer)
+	 * @param {jQuery} $container - container defined by component to be its parent
+	 * @param {boolean} isRestrict
+	 * @returns {*} - object for proper rule that insert new component to the DOM has two properties:
+	 *  - direction has value 'before', 'after' or 'append'
+	 *  - element it's HTML element (for before and after direction it is sibling, for append it is parent element)
+	 * @private
+	 */
     _getInsertedRule(targetInfo, $container, isRestrict, containerInfo) {
         var $target = $(targetInfo.element),
             pos = targetInfo.pointFromIFrame,

--- a/design-editor/src/templates/.eslintrc.json
+++ b/design-editor/src/templates/.eslintrc.json
@@ -7,6 +7,7 @@
 			"double"
 		],
 		"no-undef": "off",
-		"no-empty": "off"
+		"no-empty": "off",
+		"complexity": "off"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "TAU Design editor",
   "main": ".",
   "scripts": {
+    "eslint" : "eslint design-editor/",
     "lint": "lint-diff $TRAVIS_COMMIT_RANGE",
     "test:watt": "echo \"Testing WATT...\" && cross-env EDITOR=WATT mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",
     "test:vsc": "echo \"Testing VSC...\" && cross-env EDITOR=VSC mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",

--- a/tau-component-packages/components/header/package.json
+++ b/tau-component-packages/components/header/package.json
@@ -27,6 +27,9 @@
       "checkbox",
       "radio"
   ],
+  "parent-constraint": [
+    "page"
+  ],
   "section": "header",
   "class": [
     {


### PR DESCRIPTION
Issue: #262
Problem: User cannot add header to the empty page
Solution: Enable adding by defining parents-constraint

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>