### PR TITLE
Enable dragging listview itself

### DIFF
--- a/tau-component-packages/components/listview/package.json
+++ b/tau-component-packages/components/listview/package.json
@@ -2,6 +2,7 @@
   "label": "Listview",
   "selector": ".ui-listview",
   "attachable": true,
+  "draggable": true,
   "type": "container-component",
   "displayOrderWeight": 500,
   "resources": {


### PR DESCRIPTION
Issue:v #174
Problem: Listview cannot be moved
Solution: Add draggable option to widget package.json

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>