### PR TITLE
Make input-text, input-number, progress widgets selectable and draggable

### DIFF
--- a/closet-default-component-packages/components/input-number/package.json
+++ b/closet-default-component-packages/components/input-number/package.json
@@ -1,6 +1,6 @@
 {
     "label": "Input Number",
-    "selector": "input[type=number], .ui-text-input-container.ui-text-input-type-number",
+    "selector": "input[type=number], .ui-text-input-container, .ui-text-input-container.ui-text-input-type-number",
     "baseElementSelector": "input[type=number]",
     "attachable": true,
     "displayOrderWeight": 800,

--- a/closet-default-component-packages/components/input-text/package.json
+++ b/closet-default-component-packages/components/input-text/package.json
@@ -1,7 +1,7 @@
 {
     "name": "input-text",
     "label": "Input Text",
-    "selector": "input[type=text], .ui-text-input-container.ui-text-input-type-text",
+    "selector": "input[type=text], .ui-text-input-container, .ui-text-input-container.ui-text-input-type-text",
     "baseElementSelector": "input[type=text]",
     "attachable": true,
     "displayOrderWeight": 900,

--- a/tau-component-packages/components/progress/package.json
+++ b/tau-component-packages/components/progress/package.json
@@ -80,5 +80,7 @@
       "size": "full",
       "thickness": "null"
     }
-  }
+  },
+  "resizable": true,
+  "draggable": true
 }


### PR DESCRIPTION
[Issue]: #323
[Problem]: Widget progress, input-number and input-text are not selectable, draggable.
[Solution]: Make a few changes in package.json of each widget.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>