### PR TITLE
Widget progress draggable in wearable profile.

### DIFF
--- a/tau-component-packages/components/progress/package.json
+++ b/tau-component-packages/components/progress/package.json
@@ -1,6 +1,6 @@
 {
   "label": "Progress",
-  "selector": ".ui-circle-progress, .ui-progress",
+  "selector": ".ui-circle-progress, .ui-progress, .ui-progressbar",
   "attachable": true,
   "type": "standalone-component",
   "displayOrderWeight": 1500,


### PR DESCRIPTION
[Issue]: #323
[Problem]: Widget progress is not selectable and draggable in wearable profile.
[Solution]: Add correct class to identify progress in wearable.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>