### PR TITLE
Hide description of selected element on top bar

### DIFF
--- a/design-editor/styles/design-editor/panel.less
+++ b/design-editor/styles/design-editor/panel.less
@@ -28,7 +28,8 @@
     overflow: hidden;
 
     .closet-panel-container-middle {
-        opacity: 0;
+		opacity: 0;
+		min-width: 470px;
     }
 
     &.full {


### PR DESCRIPTION
[Problem]: Too long header description hides additional panels - for example structure view.
[Solution]: Add min-width to middle-container of design-editor which activates hiding too long description
[Issue]: #322