### PR TITLE
Show add buttons if section changer is active

### DIFF
--- a/design-editor/styles/design-editor/design-editor-element.less
+++ b/design-editor/styles/design-editor/design-editor-element.less
@@ -242,7 +242,6 @@ closet-section-controller {
         top: 50%;
         transform: translate(0, -50%);
         position: absolute;
-        opacity: 0;
         z-index: 100;
         &.closet-section-add-btn-right {
             right: 40px;
@@ -252,9 +251,6 @@ closet-section-controller {
             left: 40px;
         }
 
-        &:hover {
-            opacity: 1;
-        }
         &:active {
             color: #858585;
         }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/326
[Problem] Section changer add buttons are hidden. To make them visible,
          user must hover on them.
[Solution] Show add buttons if section changer is active.
[Test]
    1. Open Sample TAU application.
    2. Drag&Drop "Section Changer" widget.
    3. Click "Section Changer" widget.
    4. Add buttons (on left and rigt) should be visible.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>