### PR TITLE
Can't add widgets to section

### DIFF
--- a/tau-component-packages/components/section/package.json
+++ b/tau-component-packages/components/section/package.json
@@ -19,7 +19,21 @@
     "closet-tau-circle-progress",
     "box",
     "button",
-    "toggleslider"
+    "toggleslider",
+    "graph",
+    "closet-image",
+    "audio",
+    "input-text",
+    "input-number",
+    "input-password",
+    "input-date",
+    "dimmer",
+    "slider",
+    "i3d",
+    "coverflow",
+    "dropdownmenu",
+    "video",
+    "progress"
   ],
   "selector": ".ui-section-changer section",
   "template": "<section><span>Section</span></section>"

--- a/tau-component-packages/components/sectionchanger/package.json
+++ b/tau-component-packages/components/sectionchanger/package.json
@@ -139,6 +139,7 @@
       "description": "declare to section tag width to fill content or not"
     }
   ],
+  "resizable": true,
   "class": [],
   "events": [
     "sectionchange"


### PR DESCRIPTION
[Issue]https://github.com/Samsung/TAU-Design-Editor/issues/381
[Problem]There are missing the component constraint
[Solution]Add the component constraint

Signed-off-by: cookie <cookie@samsung.com>