### PR TITLE
No src set by default in image widget

### DIFF
--- a/design-editor/src/panel/property/attribute/attribute-element-image.js
+++ b/design-editor/src/panel/property/attribute/attribute-element-image.js
@@ -151,7 +151,7 @@ class AttributeImage extends DressElement {
 	}
 
 	_updateImageSourcePath(sourcePath) {
-		if (!sourcePath) {
+		if (!sourcePath || sourcePath === '#') {
 			this.$el.find('#srcImageChoose').show();
 			this.$el.find('#srcImageShow').hide();
 			this.$el.find('#srcImageFile').val('');


### PR DESCRIPTION
[Problem]: In image attributes widget has a src=# before any file is chosen
[Solution]: Show a template without source of file when src=#
[Issue]: #339

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>