### PR TITLE
Fix HTML Assistant closing when element deselected

### DIFF
--- a/brackets-extension/design-editor/libs/html-assistant-editor.js
+++ b/brackets-extension/design-editor/libs/html-assistant-editor.js
@@ -71,6 +71,14 @@ class HTMLAssistantEditor extends DressElement {
 	}
 
 	/**
+	 * Cleaning function
+	 */
+	clean() {
+		// Stub for VSC extension API compatibility
+	}
+
+
+	/**
 	 * Check if editor is opened
 	 * @returns {boolean} true if document is open
 	 */

--- a/design-editor/src/pane/select-layer/html-assistant.js
+++ b/design-editor/src/pane/select-layer/html-assistant.js
@@ -57,13 +57,16 @@ class HTMLAssistant {
 					this._htmlAssistantEditor.clean();
 					eventEmitter.emit(EVENTS.CloseInstantTextEditor);
 				})
-				.catch(error => console.error(error));
+				.catch(error => console.error(error))
+				.then(() => {
+					callback(opened);
+				});
 
 		} else {
 			this._htmlAssistantEditor.open(this.getSelectedContent(this.element));
 			eventEmitter.emit(EVENTS.OpenInstantTextEditor);
+			callback(opened);
 		}
-		callback(opened);
 	}
 
 	_bindEvents () {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/407
[Problem] HTML assistant not saving content when DE squared area click.
[Solution] Fixed callback call which should be done after promises resolve.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>