### PR TITLE
Fix HTML Assistant updating value of second element

### DIFF
--- a/brackets-extension/design-editor/libs/html-assistant-editor.js
+++ b/brackets-extension/design-editor/libs/html-assistant-editor.js
@@ -71,6 +71,14 @@ class HTMLAssistantEditor extends DressElement {
 	}
 
 	/**
+	 * Cleaning function
+	 */
+	clean() {
+		// Stub for VSC extension API compatibility
+	}
+
+
+	/**
 	 * Check if editor is opened
 	 * @returns {boolean} true if document is open
 	 */

--- a/brackets-extension/design-editor/libs/html-assistant-editor.js
+++ b/brackets-extension/design-editor/libs/html-assistant-editor.js
@@ -105,11 +105,13 @@ class HTMLAssistantEditor extends DressElement {
 	}
 
 	/**
-	 * Returns current content from editor
-	 * @returns {string} editor content
+	 * Gets current content from editor
+	 * @returns {Promise} resolves with editor content
 	 */
 	getEditorContent() {
-		return this._textEditor.document.getText();
+		return new Promise((resolve) => {
+			resolve(this._textEditor.document.getText());
+		});
 	}
 
 	layout(x, y) {

--- a/design-editor/src/pane/select-layer/html-assistant.js
+++ b/design-editor/src/pane/select-layer/html-assistant.js
@@ -57,13 +57,16 @@ class HTMLAssistant {
 					this._htmlAssistantEditor.clean();
 					eventEmitter.emit(EVENTS.CloseInstantTextEditor);
 				})
-				.catch(error => console.error(error));
+				.catch(error => console.error(error))
+				.then(() => {
+					callback(opened);
+				});
 
 		} else {
 			this._htmlAssistantEditor.open(this.getSelectedContent(this.element));
 			eventEmitter.emit(EVENTS.OpenInstantTextEditor);
+			callback(opened);
 		}
-		callback(opened);
 	}
 
 	_bindEvents () {


### PR DESCRIPTION
[Issue] #408
[Problem] HTML Assistant updating value of second element instead of selected one
[Solution]
In situation when one element selected and clicked another one
1. Avoid reseting selected item
2. Cache element id to avoid using previous one

Additionally getEditorContent() was rewritten into promise
to keep API compatibility with VSCode implementation

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>