### PR TITLE
Build SectionChanger widget in circle-helper.js

### DIFF
--- a/design-editor/src/templates/circle-helper.js
+++ b/design-editor/src/templates/circle-helper.js
@@ -27,7 +27,8 @@ function onShow(event) {
 		toggleSwitches: new Component("input[data-appearance]", tau.widget.ToggleSwitch),
 		dimmers: new Component(".ui-dimmer", tau.widget.Dimmer),
 		graphs: new Component(".ui-graph", tau.widget.Graph),
-		progressBars: new Component(".ui-circle-progress", tau.widget.CircleProgressBar)
+		progressBars: new Component(".ui-circle-progress", tau.widget.CircleProgressBar),
+		sectionChanger: new Component(".ui-section-changer", tau.widget.SectionChanger)
 	};
 
 	Object.keys(components).forEach(function(componentName) {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/346

[Problem] On Wearable profile, in DE Preview, sections are displayed as list
	and can not be scrolled.
	The same issue occurs if html already contains section changer object
	and DE is opened.

[Cause] SectionChanger is being built only after D&D operation in DE whereas
                while going to Preview, SectionChanger attributes like
                'id', 'data-tau-built' are missing.

[Solution] Build SectionChanger widget in circle-helper.js

[Test]
        1. Enable SecionChanger by reverting https://github.com/Samsung/TAU-Design-Editor/pull/372
        2. Build DE.
        3. Open TAU Base Application on Wearable.
        4. Add SectionChanger object.
        5. Add more sections by pressing '+' button.
        6. Go to Preview.
        7. You should be able to swipe sections.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>