### PR TITLE
Coverflow widget show selected files after losing focus.

### DIFF
--- a/design-editor/src/panel/property/attribute/templates/attribute-coverflow.html
+++ b/design-editor/src/panel/property/attribute/templates/attribute-coverflow.html
@@ -1,6 +1,11 @@
-<li>
+<li id ="srcCoverFlowInput">
     <span class="closet-attribute-common-label-long">Files Selection</span>
     <input type="file" id="cfFiles" name="files" multiple="multiple">
+</li>
+<li id="srcCoverFlowShow" style="display:none;">
+    <span class="closet-attribute-common-label-long">src</span>
+    <input type="text" readonly="readonly" id="srcCoverflowValue" class="closet-attribute-common-textbox">
+    <button id="srcCoverflowClear">Remove</button>
 </li>
 <li id="coverflowEffect">
     <span class="closet-attribute-common-label-long">Effect Selection</span>

--- a/design-editor/src/utils/attribute-utils.js
+++ b/design-editor/src/utils/attribute-utils.js
@@ -76,31 +76,6 @@ export default {
 		}
 	},
 
-	copyToImagesForCoverFlow(event, count) {
-		for (let i = 0; i < count; i++) {
-			[].slice.call(event.target.files).forEach(file => {
-				const reader = new FileReader();
-				reader.addEventListener('loadend', event => {
-					if (event.target.readyState === FileReader.DONE) {
-						const
-							filePath = path.join('images', file.name),
-							writePath = pathUtils.createProjectPath(filePath);
-
-						utils.checkGlobalContext('writeFile') (
-							writePath,
-							event.target.result, {
-								encoding: 'binary'
-							},
-							() => {
-							}
-						);
-					}
-				});
-				reader.readAsBinaryString(file);
-			});
-		}
-	},
-
 	/**
 	 * Set a source to interactive model
 	 * @param {Event} event


### PR DESCRIPTION
[Problem]: After losing focus coverflow widget doesn't see previous added images to it.
[Solution]: Add button to remove images from coverflow and check is data-effect attribute exists. If yes, set to input.
[Issue]: #359