### PR TITLE
Restore SectionChanger

### DIFF
--- a/tau-component-packages/package.js
+++ b/tau-component-packages/package.js
@@ -16,6 +16,7 @@ module.exports = {
 		'radio': 'components/radio',
 		'toggleswitch': 'components/toggleswitch',
 		'popup': 'components/popup',
+		'sectionchanger': 'components/sectionchanger',
 		'section': 'components/section',
 		'selector': 'components/selector',
 		'selectoritem': 'components/selectoritem',


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/398
[Problem] SectionChanger was removed in https://github.com/Samsung/TAU-Design-Editor/pull/372
	due to bugs.
[Solution] Add SectionChanger since important bugs are already fixed.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>