### PR TITLE
Restore import of style-manager in interaction.js

### DIFF
--- a/design-editor/src/pane/interaction.js
+++ b/design-editor/src/pane/interaction.js
@@ -9,6 +9,7 @@ import {SnapGuideManager} from './snap-guide-manager';
 import {eventEmitter, EVENTS} from '../events-emitter';
 import {ElementDetector} from './element-detector';
 import editor from '../editor';
+import './style-manager';
 
 let snapGuideManager = null,
     snapToContainerEnabled = false,


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/416
[Problem] User cannot set predefined styles to element
[Solution] Restore import of style-manager in interaction.js

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>