### PR TITLE
Add circle style for image

### DIFF
--- a/closet-component-packages/components/image/package.json
+++ b/closet-component-packages/components/image/package.json
@@ -8,6 +8,29 @@
   "template": "<img class=\"ui-picture\" src=\"#\" alt=\"\" style=\"height: 100px; width: 100px; display:block; background:#cacaca\">",
   "resizable": true,
   "draggable": true,
+  "data": [
+    {
+	"option": "style",
+	"values": [
+		{
+		"text": "circle",
+		"description": "Image gets a circle shape"
+		}
+	]
+	}
+	],
+	"attributes": {
+		"border-radius": {
+			"label": "Style",
+			"type": {
+			  "name": "select"
+			},
+			"list": [
+			  { "value": "", "label": "", "checkSelected": true },
+			  { "value": "50%", "label": "circle" }
+			]
+		  }
+	},
   "resources": {
     "js": "image.js",
     "css": "image.css",

--- a/design-editor/src/panel/property/attribute/attribute-element.js
+++ b/design-editor/src/panel/property/attribute/attribute-element.js
@@ -289,10 +289,15 @@ class Attribute extends DressElement {
 						typeElement.setAttribute('attr-name', optionName);
 						typeElement.$el.on('change', (e) => {
 							const value = (typeName === 'checkbox') ? e.target.checked : typeElement.value;
-							if (designEditor && value !== undefined) {
+							if (designEditor && value !== undefined && optionName.match(/^data-|^st-/)) {
 								designEditor
 									.getModel()
 									.updateAttribute(self._selectedElementId, optionName, value);
+							} else {
+								designEditor
+									.getModel()
+									.updateStyle(self._selectedElementId, optionName, value);
+								attributeObject.value = value;
 							}
 						});
 


### PR DESCRIPTION
[Problem]: Image widget hasn't got a style to be in circle shape
[Solution]: Add some attributes to image widget package.json and update style of widget.
[Issue]: #420
Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>