### PR TITLE
Add nyc test-coverage to TAU-DE

### DIFF
--- a/design-editor/src/panel/property/attribute/attribute-element.js
+++ b/design-editor/src/panel/property/attribute/attribute-element.js
@@ -730,10 +730,18 @@ class Attribute extends DressElement {
      */
     onCommonStyleChange(event, originalTarget) {
         var target = originalTarget || event.target,
+            $target = $(target),
             editor = AppManager.getActiveDesignEditor(),
             model = editor.getModel(),
             name = target.name,
             value = target.value;
+
+        // Check if input value is changed.
+        if ($target.is('input:text') && $(target).data("lastval") == value) {
+            return;
+        } else {
+            $(target).data("lastval", value);
+        }
 
         if (this._selectedElementId && name) {
             if (name === 'content') {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "eslint": "eslint design-editor/",
     "lint": "lint-diff $TRAVIS_COMMIT_RANGE",
-    "test:watt": "echo \"Testing WATT...\" && cross-env EDITOR=WATT mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",
-    "test:vsc": "echo \"Testing VSC...\" && cross-env EDITOR=VSC mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",
+    "test:watt": "echo \"Testing WATT...\" && cross-env EDITOR=WATT nyc mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",
+    "test:vsc": "echo \"Testing VSC...\" && cross-env EDITOR=VSC nyc mocha --reporter progress --require babel-polyfill --require @babel/register --require jsdom-global/register --recursive",
     "test": "npm run test:watt && npm run test:vsc",
     "coverage": "nyc npm run test",
     "build-watt": "cross-env EDITOR=WATT webpack --config tools/build.watt.config.js --config-name production",


### PR DESCRIPTION
[Problem] There was no test coverage information in TAU-De
[Solution] Add NYC which will print test coverage data

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>