### PR TITLE
Forbid input fields modification in design view

### DIFF
--- a/closet-default-component-packages/components/input-password/package.json
+++ b/closet-default-component-packages/components/input-password/package.json
@@ -4,7 +4,7 @@
   "baseElementSelector": "input[type=password]",
   "attachable": true,
   "displayOrderWeight": 1000,
-  "textEditable": true,
+  "textEditable": false,
   "type": "standalone-component",
   "resources": {
     "css": [

--- a/closet-default-component-packages/components/input-text/package.json
+++ b/closet-default-component-packages/components/input-text/package.json
@@ -6,7 +6,7 @@
     "attachable": true,
     "displayOrderWeight": 900,
     "type": "standalone-component",
-    "textEditable": true,
+    "textEditable": false,
     "resources": {
       "css": [
         "./styles/input-text.css"


### PR DESCRIPTION
Problem: text attributes are not visible in live preview for input elements

Cause: input fields are wrapped in container (div) for design editor and
	text attributes are applied to container itself but not to input field.

Solution: set textEditable option to false for input fields since
	text modification is not ready.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>