### PR TITLE
Forbid app content deleting

### DIFF
--- a/design-editor/src/pane/design-editor-element.js
+++ b/design-editor/src/pane/design-editor-element.js
@@ -1230,6 +1230,20 @@ class DesignEditor extends DressElement {
 	}
 
 	/**
+	 * Check if element can be removed
+	 * @param {Object} componentPackage
+	 * @returns {boolean}
+	 * @private
+	 */
+	_isRemovable(componentPackage) {
+		// If package does not specify 'removable' property, we assume that it can be rmeoved.
+		if (componentPackage.package.options['removable'] === undefined || componentPackage.package.options['removable']) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Callback for keyboard key down
 	 * @param {Event} event
 	 * @private
@@ -1239,7 +1253,7 @@ class DesignEditor extends DressElement {
 			selectedElement = this._getElementById(selectedElementId),
 			info = this.getUIInfo(selectedElement);
 
-		if (!selectedElement.attr('data-closed-edit-mode')) {
+		if (!selectedElement.attr('data-closed-edit-mode') && this._isRemovable(info)) {
 			if (event.keyCode === KEY_CODE.DELETE && selectedElement) {
 				event.stopImmediatePropagation();
 				elementSelector.unSelect();

--- a/tau-component-packages/components/content/package.json
+++ b/tau-component-packages/components/content/package.json
@@ -17,6 +17,7 @@
   "attachable": false,
   "resizable": false,
   "draggable": false,
+  "removable": false,
   "type": "container-component",
   "constraint": [
     "audio",


### PR DESCRIPTION
Issue: N/A
Problem: user can remove one of main app element - content. After this
	many operations do not work
Solution: add property 'removable' in content/package.json and handle it in
	design editor.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>