### PR TITLE
DesignEditor: fix of method for component replacing in model

### DIFF
--- a/design-editor/src/pane/design-editor.js
+++ b/design-editor/src/pane/design-editor.js
@@ -456,7 +456,7 @@ class Model {
     replaceElement(id, componentInfo) {
         var parentId = $(findById(this._DOM, id)).parent().attr('data-id');
         this.insert(parentId, componentInfo, id, { replace: true });
-        $(findById(this._DOM, id)).remove();
+		this.delete(id);
     }
 
     /**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/460
[Problem] After change a component style the new item appears
   in tree but old reference is not removed.
[Solution] Method for replacing element in model has been changed
    
Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
